### PR TITLE
Prototype extension: remove parent from __init__s

### DIFF
--- a/orangecontrib/prototypes/widgets/owlinearprojection.py
+++ b/orangecontrib/prototypes/widgets/owlinearprojection.py
@@ -250,8 +250,8 @@ class OWLinearProjection(widget.OWWidget):
 
     want_graph = True
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self):
+        super().__init__()
 
         self.data = None
         self.projection = None

--- a/orangecontrib/prototypes/widgets/owpolynomialregression.py
+++ b/orangecontrib/prototypes/widgets/owpolynomialregression.py
@@ -38,8 +38,8 @@ class OWPolynomialRegression(widget.OWWidget):
 
     want_main_area = True
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self):
+        super().__init__()
 
         self.data = None
         self.preprocessors = None


### PR DESCRIPTION
Widgets in Orange 3 do not have arguments in __init__