### PR TITLE
Hotplug network add-on.

### DIFF
--- a/orangecontrib/prototypes/widgets/__init__.py
+++ b/orangecontrib/prototypes/widgets/__init__.py
@@ -20,3 +20,12 @@ BACKGROUND = "#ACE3CE"
 ICON = "icons/Category-Prototypes.svg"
 
 PRIORITY = 7
+
+try:
+    # Add Orange3-Network to the list of offical add-ons
+    from Orange.canvas.application.addons import OFFICIAL_ADDONS
+    if "Orange3-Network" not in OFFICIAL_ADDONS:
+        OFFICIAL_ADDONS.append("Orange3-Network")
+except ImportError:
+    # Nothing to patch
+    pass


### PR DESCRIPTION
Hotfix for everyone that uses Orange before  https://github.com/biolab/orange3/pull/693 was merged.

Network will show in the add-ons dialog after the new version of prototype is installed.