### PR TITLE
Revert "Hotplug network add-on."

### DIFF
--- a/orangecontrib/prototypes/widgets/__init__.py
+++ b/orangecontrib/prototypes/widgets/__init__.py
@@ -20,12 +20,3 @@ BACKGROUND = "#ACE3CE"
 ICON = "icons/Category-Prototypes.svg"
 
 PRIORITY = 7
-
-try:
-    # Add Orange3-Network to the list of offical add-ons
-    from Orange.canvas.application.addons import OFFICIAL_ADDONS
-    if "Orange3-Network" not in OFFICIAL_ADDONS:
-        OFFICIAL_ADDONS.append("Orange3-Network")
-except ImportError:
-    # Nothing to patch
-    pass


### PR DESCRIPTION
Pypi search is working again, so this hotfix is no longer needed.

This reverts commit e5c9280268a0858e5d2350b20dede30ba0255ff8.