### PR TITLE
[FIX] Fix pyqtgraph 0.10 compatibility

### DIFF
--- a/orangecontrib/prototypes/widgets/owfreeviz.py
+++ b/orangecontrib/prototypes/widgets/owfreeviz.py
@@ -285,7 +285,7 @@ class OWFreeViz(widget.OWWidget):
     name = "FreeViz"
     description = "FreeViz Visualization"
     icon = "icons/LinearProjection.svg"
-    inputs = [("Data", Orange.data.Table, "set_data"),
+    inputs = [("Data", Orange.data.Table, "set_data", widget.Default),
               ("Data Subset", Orange.data.Table, "set_data_subset")]
     outputs = [("Data", Orange.data.Table, widget.Default),
                ("Selected Data", Orange.data.Table),

--- a/orangecontrib/prototypes/widgets/owfreeviz.py
+++ b/orangecontrib/prototypes/widgets/owfreeviz.py
@@ -921,6 +921,8 @@ class OWFreeViz(widget.OWWidget):
             update_freeviz(self.maxiter, interval, anchors))
         self.start_button.setText("Stop")
         self.progressBarInit(processEvents=False)
+        self.setBlocking(True)
+        self.setStatusMessage("Optimizing")
 
     def __reset_initialization(self):
         """
@@ -1004,6 +1006,8 @@ class OWFreeViz(widget.OWWidget):
     def __freeviz_finished(self):
         # Projection optimization has finished
         self.start_button.setText("Optimize")
+        self.setStatusMessage("")
+        self.setBlocking(False)
         self.progressBarFinished(processEvents=False)
         self.commit()
 

--- a/orangecontrib/prototypes/widgets/owfreeviz.py
+++ b/orangecontrib/prototypes/widgets/owfreeviz.py
@@ -8,7 +8,7 @@ import pkg_resources
 import numpy
 
 from PyQt4 import QtGui, QtCore
-from PyQt4.QtCore import Qt, QObject, QEvent, QCoreApplication
+from PyQt4.QtCore import Qt, QObject, QEvent, QLineF, QRectF, QCoreApplication
 from PyQt4.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 import pyqtgraph as pg
@@ -22,6 +22,7 @@ from Orange.widgets.visualize import owlinearprojection as linproj
 from Orange.widgets.unsupervised.owmds import mdsplotutils as plotutils
 
 from ..projection.freeviz import freeviz
+from .utils.axisitem import AxisItem
 
 
 class AsyncUpdateLoop(QObject):
@@ -272,83 +273,6 @@ class PlotToolBox(QtCore.QObject):
 
     def plotTool(self, action):
         return self.__tools[action]
-
-
-class AxisItem(pg.GraphicsObject):
-    def __init__(self, parent=None, line=None, label=None, **kwargs):
-        super().__init__(parent, **kwargs)
-        self.setFlag(pg.GraphicsObject.ItemHasNoContents)
-
-        if line is None:
-            line = QtCore.QLineF(0, 0, 1, 0)
-
-        self._spine = QtGui.QGraphicsLineItem(line, self)
-        angle = line.angle()
-
-        self._arrow = pg.ArrowItem(parent=self, angle=0)
-        self._arrow.setPos(self._spine.line().p2())
-        self._arrow.setRotation(angle)
-
-        self._label = pg.TextItem(text=label, color=(10, 10, 10))
-        self._label.setParentItem(self)
-        self._label.setPos(self._spine.line().p2())
-
-    def setLabel(self, label):
-        if label != self._label.textItem.toPlainText():
-            self._label.setText(label)
-
-    def setLine(self, *line):
-        line = QtCore.QLineF(*line)
-        if line != self._spine.line():
-            self._spine.setLine(line)
-            self.__updateLayout()
-
-    def setPen(self, pen):
-        self._spine.setPen(pen)
-
-    def setArrowVisible(self, visible):
-        self._arrow.setVisible(visible)
-
-    def paint(self, painter, option, widget):
-        pass
-
-    def boundingRect(self):
-        return QtCore.QRectF()
-
-    def viewTransformChanged(self):
-        self.__updateLayout()
-
-    def __updateLayout(self):
-        T = self.sceneTransform()
-        if T is None:
-            T = QtGui.QTransform()
-
-        # map the axis spine to scene coord. system (it should suffice to
-        # map up to PlotItem?)
-        viewbox_line = T.map(self._spine.line())
-        angle = viewbox_line.angle()
-        assert not numpy.isnan(angle)
-        # note in Qt the y axis is inverted (90 degree angle 'points' down)
-        left_quad = 270 < angle <= 360 or -0.0 <= angle < 90
-
-        # position the text label along the viewbox_line
-        label_pos = self._spine.line().pointAt(0.90)
-
-        if left_quad:
-            # Anchor the text under the axis spine
-            anchor = (0.5, -0.1)
-        else:
-            # Anchor the text over the axis spine
-            anchor = (0.5, 1.1)
-
-        self._label.setPos(label_pos)
-        self._label.anchor = pg.Point(*anchor)
-        self._label.updateText()
-        self._label.setRotation(-angle if left_quad else 180 - angle)
-
-        self._arrow.setPos(self._spine.line().p2())
-        self._arrow.setRotation(180 - angle)
-
 
 def make_pen(color, width=1.0, style=Qt.SolidLine, cap=Qt.SquareCap,
              join=Qt.BevelJoin, cosmetic=True):
@@ -772,7 +696,7 @@ class OWFreeViz(widget.OWWidget):
         axisitems = []
         for anchor, var in zip(anchors, self.data.domain.attributes):
             axitem = AxisItem(
-                line=QtCore.QLineF(0, 0, *anchor), label=var.name,)
+                line=QtCore.QLineF(0, 0, *anchor), text=var.name,)
             axitem.setVisible(numpy.linalg.norm(anchor) > minradius)
             axitem.setPen(pg.mkPen((100, 100, 100)))
             axitem.setArrowVisible(False)

--- a/orangecontrib/prototypes/widgets/utils/axisitem.py
+++ b/orangecontrib/prototypes/widgets/utils/axisitem.py
@@ -1,0 +1,98 @@
+import numpy
+
+from AnyQt.QtCore import QLineF, QRectF
+from AnyQt.QtGui import QTransform
+from AnyQt.QtWidgets import QGraphicsLineItem
+
+import pyqtgraph as pg
+
+
+class TextItem(pg.TextItem):
+    if not hasattr(pg.TextItem, "setAnchor"):
+        # Compatibility with pyqtgraph < 0.10
+        def setAnchor(self, anchor):
+            self.anchor = pg.Point(anchor)
+            self.updateText()
+
+
+class AxisItem(pg.GraphicsObject):
+    def __init__(self, parent=None, line=QLineF(), text="", **kwargs):
+        super().__init__(None, **kwargs)
+        self._text = text
+        self.setFlag(pg.GraphicsObject.ItemHasNoContents)
+
+        self._spine = QGraphicsLineItem(line, self)
+        angle = line.angle()
+
+        self._arrow = pg.ArrowItem(parent=self, angle=0)
+        self._arrow.setPos(self._spine.line().p2())
+        self._arrow.setRotation(angle)
+
+        self._label = TextItem(text=text, color=(10, 10, 10))
+        self._label.setParentItem(self)
+        self._label.setPos(self._spine.line().p2())
+
+        if parent is not None:
+            self.setParentItem(parent)
+
+    def setText(self, text):
+        if text != self._text:
+            self._text = text
+            self._label.setText(text)
+            self._label.setVisible(bool(text))
+
+    def text(self):
+        return self._text
+
+    def setLine(self, *line):
+        line = QLineF(*line)
+        if line != self._spine.line():
+            self._spine.setLine(line)
+            self.__updateLayout()
+
+    def line(self):
+        return self._spine.line()
+
+    def setPen(self, pen):
+        self._spine.setPen(pen)
+
+    def setArrowVisible(self, visible):
+        self._arrow.setVisible(visible)
+
+    def paint(self, painter, option, widget):
+        pass
+
+    def boundingRect(self):
+        return QRectF()
+
+    def viewTransformChanged(self):
+        self.__updateLayout()
+
+    def __updateLayout(self):
+        T = self.sceneTransform()
+        if T is None:
+            T = QTransform()
+
+        # map the axis spine to scene coord. system.
+        viewbox_line = T.map(self._spine.line())
+        angle = viewbox_line.angle()
+        assert not numpy.isnan(angle)
+        # note in Qt the y axis is inverted (90 degree angle 'points' down)
+        left_quad = 270 < angle <= 360 or -0.0 <= angle < 90
+
+        # position the text label along the viewbox_line
+        label_pos = self._spine.line().pointAt(0.90)
+
+        if left_quad:
+            # Anchor the text under the axis spine
+            anchor = (0.5, -0.1)
+        else:
+            # Anchor the text over the axis spine
+            anchor = (0.5, 1.1)
+
+        self._label.setPos(label_pos)
+        self._label.setAnchor(pg.Point(*anchor))
+        self._label.setRotation(-angle if left_quad else 180 - angle)
+
+        self._arrow.setPos(self._spine.line().p2())
+        self._arrow.setRotation(180 - angle)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ if __name__ == '__main__':
         },
         install_requires=[
             'Orange3',
+            'numpy',
+            'scipy',
+            'scikit-learn',
+            'pyqtgraph',
+            'AnyQt'
         ],
         entry_points=ENTRY_POINTS,
         namespace_packages=['orangecontrib'],


### PR DESCRIPTION
* Fix Freeviz/Linear projection pyqtgraph 0.10 compatibility (`AttributeError: 'TextItem'
object has no attribute 'updateText'`)
* Update/set blocking state in Freeviz during optimization
* Add `Default` flag to "Data" input in Freeviz widget