### PR TITLE
OWLookAlike: Show 100% match nicely

### DIFF
--- a/orangecontrib/prototypes/widgets/owlookalike.py
+++ b/orangecontrib/prototypes/widgets/owlookalike.py
@@ -206,7 +206,7 @@ class OWLookalike(OWWidget):
         self.neighbors_view.setModel(self.neighbors_model)
         self.neighbors_view.selectionModel().selectionChanged.connect(
             self._neighbor_changed)
-        self.neighbors_view.setMaximumWidth(202)
+        self.neighbors_view.setMaximumWidth(207)
         box.layout().addWidget(self.neighbors_view)
 
         box = gui.vBox(self.controlArea, True)
@@ -259,7 +259,7 @@ class OWLookalike(OWWidget):
         self.neighbors_view.selectionModel().select(
             selection, QItemSelectionModel.ClearAndSelect)
         self.neighbors_view.setColumnWidth(0, 160)
-        self.neighbors_view.setColumnWidth(1, 40)
+        self.neighbors_view.setColumnWidth(1, 45)
         self.apply()
 
     def set_reference(self, reference):
@@ -326,7 +326,7 @@ class OWLookalike(OWWidget):
         widget.setPos(0, 60)
         self.scene.addItem(widget)
 
-        title = QGraphicsSimpleTextItem("I am {:.3}% {}".format(
+        title = QGraphicsSimpleTextItem("I am {:.1f}% {}".format(
             self.neighbors_model[self.neighbor_index][1],
             self.neighbors_model[self.neighbor_index][0]))
         title.setFont(QFont("Garamond", 25))


### PR DESCRIPTION
When the reference image comes form the data set and we do not exclude it in the Neighbours widget we show `I am 1e+2% ...` and also the number is truncated in the left TableView. This commit changes the format to always show the full number with one decimal place and also widens TableView so that 100% matches are not truncated.