### PR TITLE
OWNeighbours: Support missing values

### DIFF
--- a/orangecontrib/prototypes/widgets/owneighbours.py
+++ b/orangecontrib/prototypes/widgets/owneighbours.py
@@ -4,6 +4,7 @@ from PyQt4.QtCore import Qt
 from PyQt4.QtGui import QApplication
 
 from Orange.data import Table, Domain, ContinuousVariable
+from Orange.preprocess import RemoveNaNColumns, Impute
 from Orange.distance import (Euclidean, Manhattan, Cosine, Jaccard, SpearmanR,
                              SpearmanRAbsolute, PearsonR, PearsonRAbsolute)
 from Orange.widgets import gui
@@ -86,8 +87,11 @@ class OWNeighbours(OWWidget):
             self.send("Neighbors", None)
             return
         distance = self.DISTANCES[self.distance_index]
-        dist = distance(np.vstack((self.data, self.reference)))[:len(self.data),
-               len(self.data):]
+        n_data, n_ref = len(self.data), len(self.reference)
+        all_data = Table.concatenate([self.reference, self.data], 0)
+        pp_all_data = Impute()(RemoveNaNColumns()(all_data))
+        pp_data, pp_reference = pp_all_data[n_ref:], pp_all_data[:n_ref]
+        dist = distance(np.vstack((pp_data, pp_reference)))[:n_data, n_data:]
         data = self._add_similarity(self.data, dist)
         sorted_indices = list(np.argsort(dist.flatten()))[::-1]
         indices = []

--- a/orangecontrib/prototypes/widgets/tests/test_owneighbours.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owneighbours.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-import Orange.widgets
+import numpy as np
+
 from Orange.data import Table
 from orangecontrib.prototypes.widgets.owneighbours import OWNeighbours
 from Orange.widgets.tests.base import WidgetTest, ParameterMapping
@@ -96,3 +97,12 @@ class TestOWNeighbours(WidgetTest):
                          neighbors.domain.class_vars)
         self.assertIn("similarity", neighbors.domain)
         self.assertTrue(all(100 >= ins["similarity"] >= 0 for ins in neighbors))
+
+    def test_missing_values(self):
+        data = Table("iris")
+        reference = data[:3]
+        data.X[0:10, 0] = np.nan
+        self.send_signal("Data", self.iris)
+        self.send_signal("Reference", reference)
+        self.widget.apply_button.button.click()
+        self.assertIsNotNone(self.get_output("Neighbors"))


### PR DESCRIPTION
The widget crashed with data with missing values. Now data is preprocessed (RemoveNaNColumns and Impute) before distances are computed.