### PR TITLE
OWCorrelations: Use heuristic to get the most promising attribute pairs

### DIFF
--- a/orangecontrib/prototypes/widgets/owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/owcorrelations.py
@@ -68,15 +68,14 @@ class CorrelationRank(VizRankDialogAttrPair):
         (a1, a2), corr_type = state, self.master.correlation_type
         X = self.master.cont_data.X
         corr = pearsonr if corr_type == CorrelationType.PEARSON else spearmanr
-        result = -corr(X[:, a1], X[:, a2])[0]
-        return result if not np.isnan(result) else NAN
+        result = corr(X[:, a1], X[:, a2])[0]
+        return -abs(result) if not np.isnan(result) else NAN, result
 
     def row_for_state(self, score, state):
         attrs = sorted((self.attrs[x] for x in state), key=attrgetter("name"))
         attr_1_item = QStandardItem(attrs[0].name)
         attr_2_item = QStandardItem(attrs[1].name)
-        score = np.nan if score == NAN else score
-        correlation_item = QStandardItem(str(round(-score, 3)))
+        correlation_item = QStandardItem("{:.3f}".format(score[1]))
         attr_1_item.setData(attrs, self._AttrRole)
         attr_2_item.setData(attrs, self._AttrRole)
         correlation_item.setData(attrs)

--- a/orangecontrib/prototypes/widgets/owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/owcorrelations.py
@@ -8,7 +8,6 @@ from sklearn.cluster import KMeans
 
 from AnyQt.QtCore import Qt, QItemSelectionModel, QItemSelection, QSize
 from AnyQt.QtGui import QStandardItem, QColor
-from AnyQt.QtWidgets import QHeaderView
 
 from Orange.data import Table, Domain, ContinuousVariable, StringVariable
 from Orange.preprocess import SklImpute, Normalize
@@ -64,7 +63,6 @@ class CorrelationRank(VizRankDialogAttrPair):
         data = self.master.cont_data
         self.attrs = data and data.domain.attributes
         self.model_proxy.setFilterKeyColumn(-1)
-        self.rank_table.horizontalHeader().setStretchLastSection(False)
         self.heuristic = KMeansCorrelationHeuristic(data) if data else None
 
     def compute_score(self, state):
@@ -201,9 +199,6 @@ class OWCorrelations(OWWidget):
         if self.cont_data is not None:
             # this triggers self.commit() by changing vizrank selection
             self.vizrank.toggle()
-            header = self.vizrank.rank_table.horizontalHeader()
-            header.setStretchLastSection(True)
-            header.setSectionResizeMode(QHeaderView.ResizeToContents)
         else:
             self.commit()
 

--- a/orangecontrib/prototypes/widgets/owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/owcorrelations.py
@@ -134,6 +134,7 @@ class OWCorrelations(OWWidget):
 
         self.vizrank, _ = CorrelationRank.add_vizrank(
             None, self, None, self._vizrank_selection_changed)
+        self.vizrank.progressBar = self.progressBar
 
         gui.separator(box)
         box.layout().addWidget(self.vizrank.filter)

--- a/orangecontrib/prototypes/widgets/owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/owcorrelations.py
@@ -28,7 +28,7 @@ class CorrelationType(IntEnum):
 
     @staticmethod
     def items():
-        return ["Pairwise Pearson correlation", "Pairwise Spearman correlation"]
+        return ["Pearson correlation", "Spearman correlation"]
 
 
 class KMeansCorrelationHeuristic:

--- a/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import time
 from Orange.data import Table
 from Orange.widgets.visualize.owscatterplot import OWScatterPlot
 from Orange.widgets.tests.base import WidgetTest
@@ -22,6 +23,7 @@ class TestOWCorrelations(WidgetTest):
     def test_input_data_cont(self):
         """Check correlation table for dataset with continuous attributes"""
         self.send_signal("Data", self.data_cont)
+        time.sleep(0.1)
         n_attrs = len(self.data_cont.domain.attributes)
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 2)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
@@ -43,6 +45,7 @@ class TestOWCorrelations(WidgetTest):
         self.send_signal("Data", self.data_mixed)
         domain = self.data_mixed.domain
         n_attrs = len([a for a in domain.attributes if a.is_continuous])
+        time.sleep(0.1)
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 2)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
                          n_attrs * (n_attrs - 1) / 2)
@@ -66,11 +69,16 @@ class TestOWCorrelations(WidgetTest):
     def test_output_data(self):
         """Check dataset on output"""
         self.send_signal("Data", self.data_cont)
+        time.sleep(0.1)
+        self.widget.commit()
         self.assertEqual(self.data_cont, self.get_output("Data"))
 
     def test_output_features(self):
         """Check features on output"""
         self.send_signal("Data", self.data_cont)
+        time.sleep(0.1)
+        attrs = self.widget.cont_data.domain.attributes
+        self.widget._vizrank_selection_changed(attrs[0], attrs[1])
         features = self.get_output("Features")
         self.assertIsInstance(features, AttributeList)
         self.assertEqual(len(features), 2)
@@ -78,6 +86,8 @@ class TestOWCorrelations(WidgetTest):
     def test_output_correlations(self):
         """Check correlation table on on output"""
         self.send_signal("Data", self.data_cont)
+        time.sleep(0.1)
+        self.widget.commit()
         correlations = self.get_output("Correlations")
         self.assertIsInstance(correlations, Table)
         self.assertEqual(len(correlations), 6)

--- a/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
@@ -2,10 +2,10 @@
 # pylint: disable=missing-docstring
 from Orange.data import Table
 from Orange.widgets.visualize.owscatterplot import OWScatterPlot
-from orangecontrib.prototypes.widgets.owcorrelations import OWCorrelations, \
-    KMeansCorrelationHeuristic
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.widget import AttributeList
+from orangecontrib.prototypes.widgets.owcorrelations import OWCorrelations, \
+    KMeansCorrelationHeuristic
 
 
 class TestOWCorrelations(WidgetTest):
@@ -94,17 +94,18 @@ class TestOWCorrelations(WidgetTest):
         self.assertIs(scatterplot_widget.attr_x, self.data_cont.domain[2])
         self.assertIs(scatterplot_widget.attr_y, self.data_cont.domain[3])
 
-    def test_KMeansCorrelationHeuristic(self):
+    def test_heuristic(self):
         """Check attribute pairs got by heuristic"""
-        h = KMeansCorrelationHeuristic(self.data_cont)
-        h.n_clusters = 2
-        self.assertListEqual(list(h.get_states(None)), [(0, 2), (0, 3), (2, 3)])
+        heuristic = KMeansCorrelationHeuristic(self.data_cont)
+        heuristic.n_clusters = 2
+        self.assertListEqual(list(heuristic.get_states(None)),
+                             [(0, 2), (0, 3), (2, 3)])
 
-    def test_KMeansCorrelationHeuristic_get_states(self):
+    def test_heuristic_get_states(self):
         """Check attribute pairs after the widget has been paused"""
-        h = KMeansCorrelationHeuristic(self.data_cont)
-        h.n_clusters = 2
-        states = h.get_states(None)
+        heuristic = KMeansCorrelationHeuristic(self.data_cont)
+        heuristic.n_clusters = 2
+        states = heuristic.get_states(None)
         _ = next(states)
-        self.assertListEqual(list(h.get_states(next(states))), [(0, 3), (2, 3)])
-
+        self.assertListEqual(list(heuristic.get_states(next(states))),
+                             [(0, 3), (2, 3)])

--- a/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
@@ -2,7 +2,8 @@
 # pylint: disable=missing-docstring
 from Orange.data import Table
 from Orange.widgets.visualize.owscatterplot import OWScatterPlot
-from orangecontrib.prototypes.widgets.owcorrelations import OWCorrelations
+from orangecontrib.prototypes.widgets.owcorrelations import OWCorrelations, \
+    KMeansCorrelationHeuristic
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.widget import AttributeList
 
@@ -92,3 +93,18 @@ class TestOWCorrelations(WidgetTest):
         self.send_signal("Features", features, widget=scatterplot_widget)
         self.assertIs(scatterplot_widget.attr_x, self.data_cont.domain[2])
         self.assertIs(scatterplot_widget.attr_y, self.data_cont.domain[3])
+
+    def test_KMeansCorrelationHeuristic(self):
+        """Check attribute pairs got by heuristic"""
+        h = KMeansCorrelationHeuristic(self.data_cont)
+        h.n_clusters = 2
+        self.assertListEqual(list(h.get_states(None)), [(0, 2), (0, 3), (2, 3)])
+
+    def test_KMeansCorrelationHeuristic_get_states(self):
+        """Check attribute pairs after the widget has been paused"""
+        h = KMeansCorrelationHeuristic(self.data_cont)
+        h.n_clusters = 2
+        states = h.get_states(None)
+        _ = next(states)
+        self.assertListEqual(list(h.get_states(next(states))), [(0, 3), (2, 3)])
+

--- a/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
@@ -22,73 +22,78 @@ class TestOWCorrelations(WidgetTest):
 
     def test_input_data_cont(self):
         """Check correlation table for dataset with continuous attributes"""
-        self.send_signal("Data", self.data_cont)
+        self.send_signal(self.widget.Inputs.data, self.data_cont)
         time.sleep(0.1)
         n_attrs = len(self.data_cont.domain.attributes)
+        self.process_events()
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 2)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
                          n_attrs * (n_attrs - 1) / 2)
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 0)
 
     def test_input_data_disc(self):
         """Check correlation table for dataset with discrete attributes"""
-        self.send_signal("Data", self.data_disc)
+        self.send_signal(self.widget.Inputs.data, self.data_disc)
         self.assertTrue(self.widget.Information.not_enough_vars.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Information.not_enough_vars.is_shown())
 
     def test_input_data_mixed(self):
         """Check correlation table for dataset with continuous and discrete
         attributes"""
-        self.send_signal("Data", self.data_mixed)
+        self.send_signal(self.widget.Inputs.data, self.data_mixed)
         domain = self.data_mixed.domain
         n_attrs = len([a for a in domain.attributes if a.is_continuous])
         time.sleep(0.1)
+        self.process_events()
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 2)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
                          n_attrs * (n_attrs - 1) / 2)
 
     def test_input_data_one_feature(self):
         """Check correlation table for dataset with one attribute"""
-        self.send_signal("Data", self.data_cont[:, [0, 4]])
+        self.send_signal(self.widget.Inputs.data, self.data_cont[:, [0, 4]])
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
         self.assertTrue(self.widget.Information.not_enough_vars.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Information.not_enough_vars.is_shown())
 
     def test_input_data_one_instance(self):
         """Check correlation table for dataset with one instance"""
-        self.send_signal("Data", self.data_cont[:1])
+        self.send_signal(self.widget.Inputs.data, self.data_cont[:1])
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
         self.assertTrue(self.widget.Information.not_enough_inst.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Information.not_enough_inst.is_shown())
 
     def test_output_data(self):
         """Check dataset on output"""
-        self.send_signal("Data", self.data_cont)
+        self.send_signal(self.widget.Inputs.data, self.data_cont)
         time.sleep(0.1)
+        self.process_events()
         self.widget.commit()
-        self.assertEqual(self.data_cont, self.get_output("Data"))
+        self.assertEqual(self.data_cont, self.get_output(self.widget.Outputs.data))
 
     def test_output_features(self):
         """Check features on output"""
-        self.send_signal("Data", self.data_cont)
+        self.send_signal(self.widget.Inputs.data, self.data_cont)
         time.sleep(0.1)
+        self.process_events()
         attrs = self.widget.cont_data.domain.attributes
         self.widget._vizrank_selection_changed(attrs[0], attrs[1])
-        features = self.get_output("Features")
+        features = self.get_output(self.widget.Outputs.features)
         self.assertIsInstance(features, AttributeList)
         self.assertEqual(len(features), 2)
 
     def test_output_correlations(self):
         """Check correlation table on on output"""
-        self.send_signal("Data", self.data_cont)
+        self.send_signal(self.widget.Inputs.data, self.data_cont)
         time.sleep(0.1)
+        self.process_events()
         self.widget.commit()
-        correlations = self.get_output("Correlations")
+        correlations = self.get_output(self.widget.Outputs.correlations)
         self.assertIsInstance(correlations, Table)
         self.assertEqual(len(correlations), 6)
         self.assertEqual(len(correlations.domain.attributes), 1)
@@ -96,11 +101,13 @@ class TestOWCorrelations(WidgetTest):
 
     def test_scatterplot_input_features(self):
         """Check if attributes have been set after sent to scatterplot"""
-        self.send_signal("Data", self.data_cont)
+        self.send_signal(self.widget.Inputs.data, self.data_cont)
         scatterplot_widget = self.create_widget(OWScatterPlot)
-        features = self.get_output("Features")
-        self.send_signal("Data", self.data_cont, widget=scatterplot_widget)
-        self.send_signal("Features", features, widget=scatterplot_widget)
+        attrs = self.widget.cont_data.domain.attributes
+        self.widget._vizrank_selection_changed(attrs[2], attrs[3])
+        features = self.get_output(self.widget.Outputs.features)
+        self.send_signal(self.widget.Inputs.data, self.data_cont, widget=scatterplot_widget)
+        self.send_signal(scatterplot_widget.Inputs.features, features, widget=scatterplot_widget)
         self.assertIs(scatterplot_widget.attr_x, self.data_cont.domain[2])
         self.assertIs(scatterplot_widget.attr_y, self.data_cont.domain[3])
 

--- a/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcorrelations.py
@@ -23,7 +23,7 @@ class TestOWCorrelations(WidgetTest):
         """Check correlation table for dataset with continuous attributes"""
         self.send_signal("Data", self.data_cont)
         n_attrs = len(self.data_cont.domain.attributes)
-        self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 3)
+        self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 2)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
                          n_attrs * (n_attrs - 1) / 2)
         self.send_signal("Data", None)
@@ -43,7 +43,7 @@ class TestOWCorrelations(WidgetTest):
         self.send_signal("Data", self.data_mixed)
         domain = self.data_mixed.domain
         n_attrs = len([a for a in domain.attributes if a.is_continuous])
-        self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 3)
+        self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 2)
         self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
                          n_attrs * (n_attrs - 1) / 2)
 


### PR DESCRIPTION
When dataset is too big (i.e too many attributes or instances), it is impossible to calculate correlations for all attribute pairs. KMeans is used to suggest the most promising attribute pairs by selecting the pair within a cluster.