### PR TITLE
[ENH] OWFeatureStatistics

### DIFF
--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -1,0 +1,604 @@
+"""
+
+TODO:
+  - Sorting by standard deviation: Use coefficient of variation (std/mean)
+    or quartile coefficient of dispersion (Q3 - Q1) / (Q3 + Q1)
+  - Standard deviation for nominal: try out Variation ratio (1 - n_mode/N)
+"""
+import locale
+from enum import IntEnum
+from functools import partial
+from typing import Any, Optional  # pylint: disable=unused-import
+
+import numpy as np
+import scipy.stats as ss
+from AnyQt.QtCore import Qt, QSize, QRectF, QVariant, \
+    QModelIndex, pyqtSlot, QRegExp
+from AnyQt.QtGui import QPainter, QColor, QKeySequence
+from AnyQt.QtWidgets import QStyleOptionViewItem, QShortcut
+from AnyQt.QtWidgets import QStyledItemDelegate, QGraphicsScene, \
+    QTableView, QHeaderView, QStyle
+
+import Orange.statistics.util as ut
+from Orange.canvas.report import plural
+from Orange.data import Table, StringVariable, DiscreteVariable, \
+    ContinuousVariable, TimeVariable, Domain, Variable
+from Orange.widgets import widget, gui
+from Orange.widgets.settings import Setting, ContextSetting, \
+    DomainContextHandler
+from Orange.widgets.utils.itemmodels import DomainModel, AbstractSortTableModel
+from Orange.widgets.utils.signals import Input
+from orangecontrib.prototypes.widgets.utils.histogram import Histogram
+
+
+class FeatureStatisticsTableModel(AbstractSortTableModel):
+    DistributionRole = next(gui.OrangeUserRole)
+
+    CLASS_VAR, META, ATTRIBUTE = range(3)
+    COLOR_FOR_ROLE = {
+        CLASS_VAR: QColor(160, 160, 160),
+        META: QColor(220, 220, 200),
+        ATTRIBUTE: QColor(255, 255, 255),
+    }
+
+    class Columns(IntEnum):
+        ICON, NAME, DISTRIBUTION, CENTER, DISPERSION, MIN, MAX, MISSING = range(8)
+
+        @property
+        def name(self):
+            return {self.ICON: '',
+                    self.NAME: 'Name',
+                    self.DISTRIBUTION: 'Distribution',
+                    self.CENTER: 'Center',
+                    self.DISPERSION: 'Dispersion',
+                    self.MIN: 'Min.',
+                    self.MAX: 'Max.',
+                    self.MISSING: 'Missing values',
+                    }[self.value]
+
+        @property
+        def index(self):
+            return self.value
+
+        @classmethod
+        def from_index(cls, index):
+            return cls(index)
+
+    def __init__(self, data=None, parent=None):
+        """
+
+        Parameters
+        ----------
+        data : Table
+        parent
+        """
+        super().__init__(parent)
+        self._data = data
+        self._domain = domain = data.domain  # type: Domain
+
+        self._attributes = domain.attributes + domain.class_vars + domain.metas
+        self.n_attributes = len(self._attributes)
+        self.n_instances = len(data)
+
+        self.__compute_statistics()
+
+    @staticmethod
+    def _attr_indices(attrs):
+        # type: (List) -> Tuple[List[int], List[int], List[int], List[int]]
+        """Get the indices of different attribute types eg. discrete."""
+        disc_var_idx = [i for i, attr in enumerate(attrs) if isinstance(attr, DiscreteVariable)]
+        cont_var_idx = [i for i, attr in enumerate(attrs)
+                        if isinstance(attr, ContinuousVariable)
+                        and not isinstance(attr, TimeVariable)]
+        time_var_idx = [i for i, attr in enumerate(attrs) if isinstance(attr, TimeVariable)]
+        string_var_idx = [i for i, attr in enumerate(attrs) if isinstance(attr, StringVariable)]
+        return disc_var_idx, cont_var_idx, time_var_idx, string_var_idx
+
+    def __compute_statistics(self):
+        # We will compute statistics over all data at once
+        matrices = [self._data.X, self._data._Y, self._data.metas]
+
+        # Since data matrices can of mixed sparsity, we need to compute
+        # attributes separately for each of them.
+        matrices = zip([
+            self._domain.attributes, self._domain.class_vars, self._domain.metas
+        ], matrices)
+        # Filter out any matrices with size 0, filter the zipped matrices to 
+        # eliminate variables in a single swoop
+        matrices = list(filter(lambda tup: tup[1].size, matrices))
+
+        def _apply_to_types(attrs_x_pair, discrete_f=None, continuous_f=None,
+                            time_f=None, string_f=None, default_val=np.nan):
+            """Apply functions to variable types e.g. discrete_f to discrete 
+            variables. Default value is returned if there is no function 
+            defined for specific variable types."""
+            attrs, x = attrs_x_pair
+            result = np.full(len(attrs), default_val)
+            disc_var_idx, cont_var_idx, time_var_idx, str_var_idx = self._attr_indices(attrs)
+            if discrete_f and x[:, disc_var_idx].size:
+                result[disc_var_idx] = discrete_f(x[:, disc_var_idx].astype(np.float64))
+            if continuous_f and x[:, cont_var_idx].size:
+                result[cont_var_idx] = continuous_f(x[:, cont_var_idx].astype(np.float64))
+            if time_f and x[:, time_var_idx].size:
+                result[time_var_idx] = time_f(x[:, time_var_idx].astype(np.float64))
+            if string_f and x[:, str_var_idx].size:
+                result[str_var_idx] = string_f(x[:, str_var_idx].astype(np.object))
+            return result
+
+        self._variable_types = [type(var) for var in self._attributes]
+        self._variable_names = [var.name.lower() for var in self._attributes]
+
+        # Compute the center
+        _center = partial(
+            _apply_to_types,
+            discrete_f=lambda x: ss.mode(x)[0],
+            continuous_f=lambda x: ut.nanmean(x, axis=0),
+        )
+        self._center = np.hstack(map(_center, matrices))
+
+        # Compute the dispersion
+        def _entropy(x):
+            p = [ut.bincount(row)[0] for row in x.T]
+            p = [pk / np.sum(pk) for pk in p]
+            return np.fromiter((ss.entropy(pk) for pk in p), dtype=np.float64)
+        _dispersion = partial(
+            _apply_to_types,
+            discrete_f=lambda x: _entropy(x),
+            continuous_f=lambda x: ut.nanvar(x, axis=0),
+        )
+        self._dispersion = np.hstack(map(_dispersion, matrices))
+
+        # Compute minimum values
+        _max = partial(
+            _apply_to_types,
+            discrete_f=lambda x: ut.nanmax(x, axis=0),
+            continuous_f=lambda x: ut.nanmax(x, axis=0),
+        )
+        self._max = np.hstack(map(_max, matrices))
+
+        # Compute maximum values
+        _min = partial(
+            _apply_to_types,
+            discrete_f=lambda x: ut.nanmin(x, axis=0),
+            continuous_f=lambda x: ut.nanmin(x, axis=0),
+        )
+        self._min = np.hstack(map(_min, matrices))
+
+        # Compute # of missing values
+        _missing = partial(
+            _apply_to_types,
+            discrete_f=lambda x: ut.countnans(x, axis=0),
+            continuous_f=lambda x: ut.countnans(x, axis=0),
+            string_f=lambda x: (x == StringVariable.Unknown).sum(axis=0),
+            time_f=lambda x: ut.countnans(x, axis=0),
+        )
+        self._missing = np.hstack(map(_missing, matrices))
+
+    def sortColumnData(self, column):
+        if column == self.Columns.ICON:
+            return self._variable_types
+        elif column == self.Columns.NAME:
+            return self._variable_names
+        elif column == self.Columns.DISTRIBUTION:
+            # TODO Implement some form of sorting over the histograms
+            return self._variable_names
+        elif column == self.Columns.CENTER:
+            return self._center
+        elif column == self.Columns.DISPERSION:
+            # Since absolute values of dispersion aren't very helpful when the
+            # variables occupy different ranges, use the coefficient of
+            # variation instead for a more reasonable sorting
+            dispersion = np.array(self._dispersion)
+            _, cont_var_indices, *_ = self._attr_indices(self._attributes)
+            dispersion[cont_var_indices] /= self._center[cont_var_indices]
+            return dispersion
+        elif column == self.Columns.MIN:
+            return self._min
+        elif column == self.Columns.MAX:
+            return self._max
+        elif column == self.Columns.MISSING:
+            return self._missing
+
+    def headerData(self, section, orientation, role):
+        # type: (int, Qt.Orientation, Qt.ItemDataRole) -> Any
+        if orientation == Qt.Horizontal:
+            if role == Qt.DisplayRole:
+                return self.Columns.from_index(section).name
+
+    def data(self, index, role):
+        # type: (QModelIndex, Qt.ItemDataRole) -> Any
+        if not index.isValid():
+            return
+
+        row, column = self.mapToSourceRows(index.row()), index.column()
+        # Make sure we're not out of range
+        if not 0 <= row <= self.n_attributes:
+            return QVariant()
+
+        output = None
+        attribute = self._attributes[row]
+
+        if column == self.Columns.ICON:
+            if role == Qt.DecorationRole:
+                return gui.attributeIconDict[attribute]
+        elif column == self.Columns.NAME:
+            if role == Qt.DisplayRole:
+                output = attribute.name
+        elif column == self.Columns.DISTRIBUTION:
+            if role == self.DistributionRole:
+                if isinstance(attribute, (DiscreteVariable, ContinuousVariable)):
+                    return attribute, self._data
+        elif column == self.Columns.CENTER:
+            if role == Qt.DisplayRole:
+                if isinstance(attribute, DiscreteVariable):
+                    output = self._center[row]
+                    if not np.isnan(output):
+                        output = attribute.str_val(self._center[row])
+                else:
+                    output = self._center[row]
+        elif column == self.Columns.DISPERSION:
+            if role == Qt.DisplayRole:
+                output = self._dispersion[row]
+        elif column == self.Columns.MIN:
+            if role == Qt.DisplayRole:
+                if isinstance(attribute, DiscreteVariable):
+                    if attribute.ordered:
+                        output = attribute.str_val(self._min[row])
+                else:
+                    output = self._min[row]
+        elif column == self.Columns.MAX:
+            if role == Qt.DisplayRole:
+                if isinstance(attribute, DiscreteVariable):
+                    if attribute.ordered:
+                        output = attribute.str_val(self._max[row])
+                else:
+                    output = self._max[row]
+        elif column == self.Columns.MISSING:
+            if role == Qt.DisplayRole:
+                output = '%d (%d%%)' % (
+                    self._missing[row],
+                    100 * self._missing[row] / self.n_instances
+                )
+
+        if role == Qt.BackgroundRole:
+            if attribute in self._domain.attributes:
+                return self.COLOR_FOR_ROLE[self.ATTRIBUTE]
+            elif attribute in self._domain.metas:
+                return self.COLOR_FOR_ROLE[self.META]
+            elif attribute in self._domain.class_vars:
+                return self.COLOR_FOR_ROLE[self.CLASS_VAR]
+
+        elif role == Qt.TextAlignmentRole:
+            if column == self.Columns.NAME:
+                return Qt.AlignLeft | Qt.AlignVCenter
+            return Qt.AlignRight | Qt.AlignVCenter
+
+        # Consistently format the text inside the table cells
+        # The easiest way to check for NaN is to compare with itself
+        if output != output:
+            output = 'NaN'
+        # Format ∞ properly
+        elif output in (np.inf, -np.inf):
+            output = '%s∞' % ['', '-'][output < 0]
+        elif isinstance(output, int):
+            output = locale.format('%d', output, grouping=True)
+        elif isinstance(output, float):
+            output = locale.format('%.2f', output, grouping=True)
+
+        return output
+
+    def rowCount(self, parent=QModelIndex()):
+        return 0 if parent.isValid() else self.n_attributes
+
+    def columnCount(self, parent=QModelIndex()):
+        return 0 if parent.isValid() else len(self.Columns)
+
+
+class NoFocusRectDelegate(QStyledItemDelegate):
+    """Removes the light blue background and border on a focused item."""
+
+    def paint(self, painter, option, index):
+        # type: (QPainter, QStyleOptionViewItem, QModelIndex) -> None
+        option.state &= ~QStyle.State_HasFocus
+        super().paint(painter, option, index)
+
+
+class DistributionDelegate(NoFocusRectDelegate):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.target_class_index = None
+        self.__cache = {}
+
+    def clear(self):
+        self.__cache.clear()
+
+    def set_target_class(self, new_index):
+        self.target_class_index = new_index
+        self.__cache.clear()
+
+    def paint(self, painter, option, index):
+        # type: (QPainter, QStyleOptionViewItem, QModelIndex) -> None
+        data = index.data(FeatureStatisticsTableModel.DistributionRole)
+        if data is None:
+            return super().paint(painter, option, index)
+
+        row = index.model().mapToSourceRows(index.row())
+
+        if row not in self.__cache:
+            scene = QGraphicsScene(self)
+            attribute, data = data
+            histogram = Histogram(
+                data=data,
+                variable=attribute,
+                class_index=self.target_class_index,
+                border=(0, 0, 2, 0),
+                border_color='#ccc',
+            )
+            scene.addItem(histogram)
+            self.__cache[row] = scene
+
+        painter.setRenderHint(QPainter.HighQualityAntialiasing)
+
+        if option.state & QStyle.State_Selected:
+            background_color = option.palette.highlight()
+        else:
+            background_color = index.data(Qt.BackgroundRole)
+        self.__cache[row].setBackgroundBrush(background_color)
+
+        self.__cache[row].render(
+            painter,
+            target=QRectF(option.rect),
+            mode=Qt.IgnoreAspectRatio,
+        )
+
+
+class OWFeatureStatistics(widget.OWWidget):
+    HISTOGRAM_ASPECT_RATIO = (7, 3)
+    MINIMUM_HISTOGRAM_HEIGHT = 50
+
+    name = 'Feature Statistics'
+    description = 'Show basic statistics for data features.'
+
+    class Inputs:
+        data = Input('Data', Table, default=True)
+
+    want_main_area = True
+    buttons_area_orientation = Qt.Vertical
+
+    settingsHandler = DomainContextHandler()
+
+    auto_commit = Setting(True)
+    target_var = ContextSetting(None)  # type: Variable
+    filter_string = ContextSetting('')
+
+    def __init__(self):
+        super().__init__()
+
+        self.data = None  # type: Optional[Table]
+        self.model = None  # type: Optional[FeatureStatisticsTableModel]
+
+        # Information panel
+        info_box = gui.vBox(self.controlArea, 'Info')
+        info_box.setMinimumWidth(200)
+        self.info_summary = gui.widgetLabel(info_box, wordWrap=True)
+        self.info_attr = gui.widgetLabel(info_box, wordWrap=True)
+        self.info_class = gui.widgetLabel(info_box, wordWrap=True)
+        self.info_meta = gui.widgetLabel(info_box, wordWrap=True)
+        self.set_info()
+
+        filter_box = gui.vBox(self.controlArea, 'Filter')
+
+        self.filter_text = gui.lineEdit(
+            filter_box, self, value='filter_string',
+            placeholderText='Filter variables by name',
+            callback=self._filter_table_variables, callbackOnType=True,
+        )
+        shortcut = QShortcut(QKeySequence('Ctrl+f'), self, self.filter_text.setFocus)
+        shortcut.setWhatsThis('Filter variables by name')
+
+        self.target_var_model = DomainModel(
+            order=DomainModel.CLASSES, placeholder='None',
+        )
+        target_var_box = gui.vBox(self.controlArea, 'Histogram')
+        self.cb_target_var_index = gui.comboBox(
+            target_var_box, master=self, value='target_var',
+            model=self.target_var_model, label='Target class',
+        )
+        self.cb_target_var_index.currentIndexChanged.connect(self.__target_class_changed)
+
+        gui.rubber(self.controlArea)
+        gui.auto_commit(
+            self.buttonsArea, self, 'auto_commit', 'Send Selected Rows',
+            'Send Automatically'
+        )
+
+        # Main area
+        self.view = QTableView(
+            showGrid=False,
+            cornerButtonEnabled=False,
+            sortingEnabled=True,
+            selectionBehavior=QTableView.SelectRows,
+            selectionMode=QTableView.MultiSelection,
+            horizontalScrollMode=QTableView.ScrollPerPixel,
+            verticalScrollMode=QTableView.ScrollPerPixel,
+        )
+
+        hheader = self.view.horizontalHeader()
+        hheader.setStretchLastSection(False)
+        # Contents precision specifies how many rows should be taken into
+        # account when computing the sizes, 0 being the visible rows. This is
+        # crucial, since otherwise the `ResizeToContents` section resize mode
+        # would call `sizeHint` on every single row in the data before first
+        # render. However this, this cannot be used here, since this only
+        # appears to work properly when the widget is actually shown. When the
+        # widget is not shown, size `sizeHint` is called on every row.
+        hheader.setResizeContentsPrecision(5)
+        # Set a nice default size so that headers have some space around titles
+        hheader.setDefaultSectionSize(120)
+        # Set individual column behaviour in `set_data` since the logical
+        # indices must be valid in the model, which requires data.
+        hheader.setSectionResizeMode(QHeaderView.Interactive)
+
+        vheader = self.view.verticalHeader()
+        vheader.setVisible(False)
+        vheader.setSectionResizeMode(QHeaderView.Fixed)
+
+        def bind_histogram_aspect_ratio(logical_index, _, new_size):
+            """Force the horizontal and vertical header to maintain the defined
+            aspect ratio specified for the histogram."""
+            # Prevent function being exectued more than once per resize
+            if logical_index is not self.model.Columns.DISTRIBUTION.index:
+                return
+            ratio_width, ratio_height = self.HISTOGRAM_ASPECT_RATIO
+            unit_width = new_size / ratio_width
+            new_height = unit_width * ratio_height
+            effective_height = max(new_height, self.MINIMUM_HISTOGRAM_HEIGHT)
+            vheader.setDefaultSectionSize(effective_height)
+
+        def keep_row_centered(logical_index, old_size, new_size):
+            """When resizing the widget when scrolled further down, the
+            positions of rows changes. Obviously, the user resized in order to
+            better see the row of interest. This keeps that row centered."""
+            # TODO: This does not work properly
+            # Prevent function being exectued more than once per resize
+            if logical_index is not self.model.Columns.DISTRIBUTION.index:
+                return
+            top_row = self.view.indexAt(self.view.rect().topLeft()).row()
+            bottom_row = self.view.indexAt(self.view.rect().bottomLeft()).row()
+            middle_row = top_row + (bottom_row - top_row) // 2
+            self.view.scrollTo(self.model.index(middle_row, 0), QTableView.PositionAtCenter)
+
+        hheader.sectionResized.connect(bind_histogram_aspect_ratio)
+        hheader.sectionResized.connect(keep_row_centered)
+
+        self.distribution_delegate = DistributionDelegate()
+        self.view.setItemDelegate(self.distribution_delegate)
+
+        self.mainArea.layout().addWidget(self.view)
+
+    def sizeHint(self):
+        return QSize(900, 500)
+
+    def _filter_table_variables(self):
+        regex = QRegExp(self.filter_string)
+        # If the user explicitly types different cases, we assume they know
+        # what they are searching for and account for letter case in filter
+        different_case = (
+            any(c.islower() for c in self.filter_string) and
+            any(c.isupper() for c in self.filter_string)
+        )
+        if not different_case:
+            regex.setCaseSensitivity(Qt.CaseInsensitive)
+
+    @Inputs.data
+    def set_data(self, data):
+        self.closeContext()
+        self.data = data
+
+        if data is not None:
+            self.model = FeatureStatisticsTableModel(data, parent=self)
+            self.target_var_model.set_domain(data.domain)
+            # Set the selected index to 1 if any target classes, otherwise 0
+            if len(self.target_var_model) >= 2:
+                self.target_var = self.target_var_model[1]
+            self.openContext(self.data)
+        else:
+            self.model = None
+            self.target_var_model.set_domain(None)
+
+        self.view.setModel(self.model)
+        self._filter_table_variables()
+
+        self.distribution_delegate.clear()
+        self.set_info()
+
+        # The resize modes for individual columns must be set here, because
+        # the logical index must be valid in `setSectionResizeMode`. It is not
+        # valid when there is no data in the model.
+        if self.model:
+            columns, hheader = self.model.Columns, self.view.horizontalHeader()
+            hheader.setSectionResizeMode(columns.ICON.index, QHeaderView.ResizeToContents)
+            hheader.setSectionResizeMode(columns.DISTRIBUTION.index, QHeaderView.Stretch)
+
+    @pyqtSlot(int)
+    def __target_class_changed(self, new_index):
+        self.distribution_delegate.set_target_class(
+            None if new_index < 1 else new_index - 1
+        )
+
+        if self.model:
+            for row_idx in range(self.model.rowCount()):
+                index = self.model.index(
+                    row_idx,
+                    self.model.Columns.DISTRIBUTION.index)
+                self.view.update(index)
+
+    @staticmethod
+    def _format_variables_string(variables):
+        agg = []
+        for var_type_name, var_type in [
+            ('categorical', DiscreteVariable),
+            ('numeric', ContinuousVariable),
+            ('time', TimeVariable),
+            ('string', StringVariable)
+        ]:
+            var_type_list = [v for v in variables if isinstance(v, var_type)]
+            if var_type_list:
+                agg.append((
+                    '%d %s' % (len(var_type_list), var_type_name),
+                    len(var_type_list)
+                ))
+
+        if not agg:
+            return 'No variables'
+
+        attrs, counts = list(zip(*agg))
+        if len(attrs) > 1:
+            var_string = ', '.join(attrs[:-1]) + ' and ' + attrs[-1]
+        else:
+            var_string = attrs[0]
+        return plural('%s variable{s}' % var_string, sum(counts))
+
+    def set_info(self):
+        if self.data is not None:
+            self.info_summary.setText('<b>%s</b> contains %s with %s' % (
+                self.data.name,
+                plural('{number} instance{s}', self.model.n_instances),
+                plural('{number} feature{s}', self.model.n_attributes)
+            ))
+
+            self.info_attr.setText(
+                '<b>Attributes:</b><br>%s' %
+                self._format_variables_string(self.data.domain.attributes)
+            )
+            self.info_class.setText(
+                '<b>Class variables:</b><br>%s' %
+                self._format_variables_string(self.data.domain.class_vars)
+            )
+            self.info_meta.setText(
+                '<b>Metas:</b><br>%s' %
+                self._format_variables_string(self.data.domain.metas)
+            )
+        else:
+            self.info_summary.setText('No data on input.')
+            self.info_attr.setText('')
+            self.info_class.setText('')
+            self.info_meta.setText('')
+
+    def commit(self):
+        pass
+
+    def send_report(self):
+        pass
+
+
+if __name__ == '__main__':
+    from AnyQt.QtWidgets import QApplication
+    import sys
+
+    app = QApplication(sys.argv)
+    ow = OWFeatureStatistics()
+
+    ow.set_data(Table(sys.argv[1] if len(sys.argv) > 1 else 'iris'))
+    ow.show()
+    app.exec_()

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -388,15 +388,15 @@ class OWFeatureStatistics(widget.OWWidget):
         self.info_meta = gui.widgetLabel(info_box, wordWrap=True)
         self.set_info()
 
-        filter_box = gui.vBox(self.controlArea, 'Filter')
-
-        self.filter_text = gui.lineEdit(
-            filter_box, self, value='filter_string',
-            placeholderText='Filter variables by name',
-            callback=self._filter_table_variables, callbackOnType=True,
-        )
-        shortcut = QShortcut(QKeySequence('Ctrl+f'), self, self.filter_text.setFocus)
-        shortcut.setWhatsThis('Filter variables by name')
+        # TODO: Implement filtering on the model
+        # filter_box = gui.vBox(self.controlArea, 'Filter')
+        # self.filter_text = gui.lineEdit(
+        #     filter_box, self, value='filter_string',
+        #     placeholderText='Filter variables by name',
+        #     callback=self._filter_table_variables, callbackOnType=True,
+        # )
+        # shortcut = QShortcut(QKeySequence('Ctrl+f'), self, self.filter_text.setFocus)
+        # shortcut.setWhatsThis('Filter variables by name')
 
         self.target_var_model = DomainModel(
             valid_types=(ContinuousVariable, DiscreteVariable),

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -355,6 +355,7 @@ class DistributionDelegate(NoFocusRectDelegate):
 class OWFeatureStatistics(widget.OWWidget):
     HISTOGRAM_ASPECT_RATIO = (7, 3)
     MINIMUM_HISTOGRAM_HEIGHT = 50
+    MAXIMUM_HISTOGRAM_HEIGHT = 100
 
     name = 'Feature Statistics'
     description = 'Show basic statistics for data features.'
@@ -453,6 +454,7 @@ class OWFeatureStatistics(widget.OWWidget):
             unit_width = new_size / ratio_width
             new_height = unit_width * ratio_height
             effective_height = max(new_height, self.MINIMUM_HISTOGRAM_HEIGHT)
+            effective_height = min(effective_height, self.MAXIMUM_HISTOGRAM_HEIGHT)
             vheader.setDefaultSectionSize(effective_height)
 
         def keep_row_centered(logical_index, old_size, new_size):

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -275,7 +275,7 @@ class TestOWFeatureStatistics(WidgetTest):
             time_full,
         ])
         self.send_signal('Data', prepare_table(data))
-        simulate.combobox_run_through_all(self.widget.cb_target_var_index)
+        simulate.combobox_run_through_all(self.widget.cb_color_var)
 
     @table_dense_sparse
     def test_runs_with_missing_target_values(self, prepare_table):
@@ -293,7 +293,7 @@ class TestOWFeatureStatistics(WidgetTest):
         self.send_signal('Data', prepare_table(data))
         # TODO: This does not actually test the crash because the histogram
         # code only runs when visible
-        simulate.combobox_run_through_all(self.widget.cb_target_var_index)
+        simulate.combobox_run_through_all(self.widget.cb_color_var)
 
     @table_dense_sparse
     def test_runs_with_all_missing_target_values(self, prepare_table):
@@ -311,4 +311,4 @@ class TestOWFeatureStatistics(WidgetTest):
         self.send_signal('Data', prepare_table(data))
         # TODO: This does not actually test the crash because the histogram
         # code only runs when visible
-        simulate.combobox_run_through_all(self.widget.cb_target_var_index)
+        simulate.combobox_run_through_all(self.widget.cb_color_var)

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -1,0 +1,314 @@
+from functools import wraps
+from itertools import chain
+from typing import Callable
+
+import numpy as np
+
+from Orange.data import Table, Domain, StringVariable, ContinuousVariable, \
+    DiscreteVariable, TimeVariable
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.utils import simulate
+from orangecontrib.prototypes.widgets.owfeaturestatistics import \
+    OWFeatureStatistics
+
+# Continuous variable variations
+continuous_full = [
+    ContinuousVariable('continuous_full'),
+    np.array([0, 1, 2, 3, 4], dtype=float),
+]
+continuous_missing = [
+    ContinuousVariable('continuous_missing'),
+    np.array([0, 1, 2, np.nan, 4], dtype=float),
+]
+continuous_all_missing = [
+    ContinuousVariable('continuous_all_missing'),
+    np.array([np.nan] * 5, dtype=float),
+]
+continuous_same = [
+    ContinuousVariable('continuous_same'),
+    np.array([3] * 5, dtype=float),
+]
+continuous = [
+    continuous_full, continuous_missing, continuous_all_missing,
+    continuous_same
+]
+
+# Unordered discrete variable variations
+rgb_full = [
+    DiscreteVariable('rgb_full', values=['r', 'g', 'b']),
+    np.array([0, 1, 1, 1, 2], dtype=float),
+]
+rgb_missing = [
+    DiscreteVariable('rgb_missing', values=['r', 'g', 'b']),
+    np.array([0, 1, 1, np.nan, 2], dtype=float),
+]
+rgb_all_missing = [
+    DiscreteVariable('rgb_all_missing', values=['r', 'g', 'b']),
+    np.array([np.nan] * 5, dtype=float),
+]
+rgb_bins_missing = [
+    DiscreteVariable('rgb_bins_missing', values=['r', 'g', 'b']),
+    np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
+]
+rgb_same = [
+    DiscreteVariable('rgb_same', values=['r', 'g', 'b']),
+    np.array([2] * 5, dtype=float),
+]
+rgb = [
+    rgb_full, rgb_missing, rgb_all_missing, rgb_bins_missing, rgb_same
+]
+
+# Ordered discrete variable variations
+ints_full = [
+    DiscreteVariable('ints_full', values=['2', '3', '4'], ordered=True),
+    np.array([0, 1, 1, 1, 2], dtype=float),
+]
+ints_missing = [
+    DiscreteVariable('ints_missing', values=['2', '3', '4'], ordered=True),
+    np.array([0, 1, 1, np.nan, 2], dtype=float),
+]
+ints_all_missing = [
+    DiscreteVariable('ints_all_missing', values=['2', '3', '4'], ordered=True),
+    np.array([np.nan] * 5, dtype=float),
+]
+ints_bins_missing = [
+    DiscreteVariable('ints_bins_missing', values=['2', '3', '4'], ordered=True),
+    np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
+]
+ints_same = [
+    DiscreteVariable('ints_same', values=['2', '3', '4'], ordered=True),
+    np.array([0] * 5, dtype=float),
+]
+ints = [
+    ints_full, ints_missing, ints_all_missing, ints_bins_missing, ints_same
+]
+
+discrete = list(chain(rgb, ints))
+
+# Time variable variations
+time_full = [
+    TimeVariable('time_full'),
+    np.array([0, 1, 2, 3, 4], dtype=float),
+]
+time_missing = [
+    TimeVariable('time_missing'),
+    np.array([0, np.nan, 2, 3, 4], dtype=float),
+]
+time_all_missing = [
+    TimeVariable('time_all_missing'),
+    np.array([np.nan] * 5, dtype=float),
+]
+time_same = [
+    TimeVariable('time_same'),
+    np.array([4] * 5, dtype=float),
+]
+time = [
+    time_full, time_missing, time_all_missing, time_same
+]
+
+# String variable variations
+string_full = [
+    StringVariable('string_full'),
+    np.array(['a', 'b', 'c', 'd', 'e'], dtype=object),
+]
+string_missing = [
+    StringVariable('string_missing'),
+    np.array(['a', 'b', 'c', StringVariable.Unknown, 'e'], dtype=object),
+]
+string_all_missing = [
+    StringVariable('string_all_missing'),
+    np.array([StringVariable.Unknown] * 5, dtype=object),
+]
+string_same = [
+    StringVariable('string_same'),
+    np.array(['a'] * 5, dtype=object),
+]
+string = [
+    string_full, string_missing, string_all_missing, string_same
+]
+
+
+def make_table(attributes, target=None, metas=None):
+    """Build an instance of a table given various variables.
+
+    Parameters
+    ----------
+    attributes : Iterable[Tuple[Variable, np.array]
+    target : Optional[Iterable[Tuple[Variable, np.array]]
+    metas : Optional[Iterable[Tuple[Variable, np.array]]
+
+    Returns
+    -------
+    Table
+
+    """
+    attribute_vars, attribute_vals = list(zip(*attributes))
+    attribute_vals = np.array(attribute_vals).T
+
+    target_vars, target_vals = None, None
+    if target is not None:
+        target_vars, target_vals = list(zip(*target))
+        target_vals = np.array(target_vals).T
+
+    meta_vars, meta_vals = None, None
+    if metas is not None:
+        meta_vars, meta_vals = list(zip(*metas))
+        meta_vals = np.array(meta_vals).T
+
+    return Table.from_numpy(
+        Domain(attribute_vars, class_vars=target_vars, metas=meta_vars),
+        X=attribute_vals, Y=target_vals, metas=meta_vals,
+    )
+
+
+def table_dense_sparse(test_case):
+    # type: (Callable) -> Callable
+    """Run a single test case on both dense and sparse Orange tables."""
+
+    @wraps(test_case)
+    def _wrapper(self):
+        test_case(self, lambda table: table.to_dense())
+        test_case(self, lambda table: table.to_sparse())
+
+    return _wrapper
+
+
+class TestOWFeatureStatistics(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(
+            OWFeatureStatistics, stored_settings={"auto_apply": False}
+        )
+
+    @table_dense_sparse
+    def test_runs_on_iris(self, prepare_table):
+        self.send_signal('Data', prepare_table(Table('iris')))
+
+    def test_does_not_crash_on_data_removal(self):
+        self.send_signal('Data', make_table(discrete))
+        self.send_signal('Data', None)
+
+    # Only discrete variables
+    @table_dense_sparse
+    def test_runs_on_discrete_with_no_target(self, prepare_table):
+        data = make_table(discrete)
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_on_discrete_with_discrete_target(self, prepare_table):
+        data = make_table(discrete, target=[ints_full])
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_on_discrete_with_continuous_target(self, prepare_table):
+        data = make_table(discrete, target=[continuous_full])
+        self.send_signal('Data', prepare_table(data))
+
+    # Only continuous variables
+    @table_dense_sparse
+    def test_runs_on_continuous_with_no_target(self, prepare_table):
+        data = make_table(continuous)
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_on_continuous_with_discrete_target(self, prepare_table):
+        data = make_table(continuous, target=[ints_full])
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_on_continuous_with_continuous_target(self, prepare_table):
+        data = make_table(continuous, target=[continuous_full])
+        self.send_signal('Data', prepare_table(data))
+
+    # Only time variables
+    @table_dense_sparse
+    def test_runs_on_time_with_no_target(self, prepare_table):
+        data = make_table(time)
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_on_time_with_discrete_target(self, prepare_table):
+        data = make_table(time, target=[ints_full])
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_on_time_with_continuous_target(self, prepare_table):
+        data = make_table(time, target=[continuous_full])
+        self.send_signal('Data', prepare_table(data))
+
+    # With various metas
+    @table_dense_sparse
+    def test_runs_with_no_target_and_metas(self, prepare_table):
+        data = make_table(chain(continuous, discrete, time), metas=[
+            ints_missing,
+            rgb_same,
+            string_missing,
+            string_all_missing,
+            time_full,
+        ])
+        self.send_signal('Data', prepare_table(data))
+
+    @table_dense_sparse
+    def test_runs_with_target_and_metas(self, prepare_table):
+        data = make_table(chain(continuous, discrete, time), target=[
+            ints_same
+        ], metas=[
+            ints_missing,
+            rgb_same,
+            string_missing,
+            string_all_missing,
+            time_full,
+        ])
+        self.send_signal('Data', prepare_table(data))
+
+    # Various other convoluted input tables
+    @table_dense_sparse
+    def test_runs_with_multiple_targets(self, prepare_table):
+        data = make_table(chain(continuous, discrete, time), target=[
+            continuous_full,
+            rgb_full,
+            ints_full,
+        ], metas=[
+            ints_missing,
+            rgb_same,
+            string_missing,
+            string_all_missing,
+            time_full,
+        ])
+        self.send_signal('Data', prepare_table(data))
+        simulate.combobox_run_through_all(self.widget.cb_target_var_index)
+
+    @table_dense_sparse
+    def test_runs_with_missing_target_values(self, prepare_table):
+        data = make_table(chain(continuous, discrete, time), target=[
+            continuous_missing,
+            rgb_missing,
+            ints_missing,
+        ], metas=[
+            ints_missing,
+            rgb_same,
+            string_missing,
+            string_all_missing,
+            time_full,
+        ])
+        self.send_signal('Data', prepare_table(data))
+        # TODO: This does not actually test the crash because the histogram
+        # code only runs when visible
+        simulate.combobox_run_through_all(self.widget.cb_target_var_index)
+
+    @table_dense_sparse
+    def test_runs_with_all_missing_target_values(self, prepare_table):
+        data = make_table(chain(continuous, discrete, time), target=[
+            continuous_all_missing,
+            rgb_all_missing,
+            ints_all_missing,
+        ], metas=[
+            ints_missing,
+            rgb_same,
+            string_missing,
+            string_all_missing,
+            time_full,
+        ])
+        self.send_signal('Data', prepare_table(data))
+        # TODO: This does not actually test the crash because the histogram
+        # code only runs when visible
+        simulate.combobox_run_through_all(self.widget.cb_target_var_index)

--- a/orangecontrib/prototypes/widgets/utils/histogram.py
+++ b/orangecontrib/prototypes/widgets/utils/histogram.py
@@ -1,0 +1,364 @@
+import numpy as np
+from AnyQt.QtCore import Qt, QRectF, QSizeF, QPointF, QLineF
+from AnyQt.QtGui import QColor, QBrush, QPen
+from AnyQt.QtWidgets import (
+    QGraphicsWidget,
+    QGraphicsRectItem,
+    QGraphicsLinearLayout,
+    QSizePolicy,
+    QGraphicsLineItem)
+from scipy import sparse as sp
+
+import Orange.statistics.util as ut
+from Orange.data.util import one_hot
+from Orange.widgets.utils.colorpalette import ContinuousPaletteGenerator
+
+
+class BarItem(QGraphicsWidget):
+    """A single bar in a histogram representing one single target value."""
+    def __init__(self, width, height, color, parent=None):
+        super().__init__(parent=parent)
+        self.width = width
+        self.height = height
+        self.color = color
+        if not isinstance(self.color, QColor):
+            self.color = QColor(self.color)
+
+        self.__rect = QGraphicsRectItem(0, 0, self.width, self.height, self)
+        self.__rect.setPen(QPen(Qt.NoPen))
+        self.__rect.setBrush(QBrush(self.color))
+
+    def boundingRect(self):
+        return self.__rect.boundingRect()
+
+    def sizeHint(self, which, constraint):
+        return self.boundingRect().size()
+
+    def sizePolicy(self):
+        return QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+
+class ProportionalBarItem(QGraphicsLinearLayout):
+    """A bar that fills draws ``'BarItem'`` objects given some proportions.
+
+    Parameters
+    ----------
+    distribution : np.ndarray
+        Contains the counts of individual target values that belong to the
+        particular bin. This can have length 1 if there is no target class.
+    colors : Optional[Iterable[QColor]]
+        If colors are passed, they must match the shape of the distribution.
+        The bars will be colored according to these values, where the indices
+        in the distribution must match the color indices.
+    bar_size : Union[int, float]
+        The width of the bar.
+    height : Union[int, float]
+        The height of the bar.
+
+    """
+
+    def __init__(self, distribution, bar_size=10, height=100, colors=None):
+        super().__init__()
+
+        self.distribution = distribution
+
+        assert not colors or len(distribution) is len(colors), \
+            'If colors are provided, they must match the shape of distribution'
+        self.colors = colors
+
+        self.height = height
+        self.setOrientation(Qt.Vertical)
+        self._bar_size = bar_size
+
+        self.setSpacing(0)
+        self.setContentsMargins(0, 0, 0, 0)
+
+        self._draw_bars()
+
+    def _draw_bars(self):
+        heights, dist_sum = self.distribution, self.distribution.sum()
+        # If the number of instances within a column is not 0, divide by that
+        # sum to get the proportional height, otherwise set the height to 0
+        heights *= (dist_sum ** -1 if dist_sum != 0 else 0) * self.height
+
+        for idx, height in enumerate(heights):
+            color = self.colors[idx] if self.colors else QColor('#ccc')
+            self.addItem(BarItem(width=self._bar_size, height=height, color=color))
+
+    def sizeHint(self, which, constraint):
+        return QSizeF(self._bar_size, self.height)
+
+    def sizePolicy(self):
+        return QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+
+class Histogram(QGraphicsWidget):
+    """A basic histogram widget.
+
+    Parameters
+    ----------
+        data : Table
+        variable : Union[int, str, Variable]
+        parent : QObject
+        height : Union[int, float]
+        width : Union[int, float]
+        side_padding : Union[int, float]
+            Specify the padding between the edges of the histogram and the
+            first and last bars.
+        top_padding : Union[int, float]
+            Specify the padding between the top of the histogram and the
+            highest bar.
+        bar_spacing : Union[int, float]
+            Specify the amount of spacing to place between individual bars.
+        border : Union[Tuple[Union[int, float]], int, float]
+            Can be anything that can go into the ``'QColor'`` constructor.
+            Draws a border around the entire histogram in a given color.
+        border_color : Union[QColor, str]
+        class_index : int
+            The index of the target variable in ``'data'``.
+        n_bins : int
+
+    """
+
+    def __init__(self, data, variable, parent=None, height=200,
+                 width=300, side_padding=5, top_padding=20, bar_spacing=4,
+                 border=0, border_color=None, class_index=None, n_bins=10):
+        super().__init__(parent)
+        self.height, self.width = height, width
+        self.padding = side_padding
+        self.bar_spacing = bar_spacing
+
+        self.data = data
+        self.attribute = data.domain[variable]
+
+        self.x = data.get_column_view(self.attribute)[0].astype(np.float64)
+
+        if self.attribute.is_discrete:
+            self.n_bins = len(self.attribute.values)
+        elif self.attribute.is_continuous:
+            # If the attribute is continuous but contains fewer values than the
+            # bins, it is better to assign each their own bin. We will require
+            # at least 2 bins so that the histogram still visually makes sense
+            # except if there is only a single value, then we use 3 bins for
+            # symmetry
+            num_unique = ut.nanunique(self.x).shape[0]
+            if num_unique == 1:
+                self.n_bins = 3
+            else:
+                self.n_bins = min(max(2, num_unique), n_bins)
+
+        # Handle target variable index
+        self.class_index = class_index
+        if self.class_index is not None:
+            assert 0 <= class_index < len(data.domain.class_vars), \
+                'Target variable `%d` out of range!' % class_index
+            self.target_var = data.domain.class_vars[class_index]
+            self.y = data.Y[:, class_index] if data.Y.ndim > 1 else data.Y
+        else:
+            self.target_var, self.y = None, None
+
+        # Borders
+        self.border_color = border_color if border_color is not None else '#000'
+        if isinstance(border, tuple):
+            assert len(border) == 4, 'Border tuple must be of size 4.'
+            self.border = border
+        else:
+            self.border = (border, border, border, border)
+        t, r, b, l = self.border
+
+        def _draw_border(point_1, point_2, border_width, parent):
+            pen = QPen(QColor(self.border_color))
+            pen.setCosmetic(True)
+            pen.setWidth(border_width)
+            line = QGraphicsLineItem(QLineF(point_1, point_2), parent)
+            line.setPen(pen)
+            return line
+
+        top_left = QPointF(0, 0)
+        bottom_left = QPointF(0, self.height)
+        top_right = QPointF(self.width, 0)
+        bottom_right = QPointF(self.width, self.height)
+
+        self.border_top = _draw_border(top_left, top_right, t, self) if t else None
+        self.border_bottom = _draw_border(bottom_left, bottom_right, b, self) if b else None
+        self.border_left = _draw_border(top_left, bottom_left, l, self) if l else None
+        self.border_right = _draw_border(top_right, bottom_right, r, self) if r else None
+
+        # _plot_`dim` accounts for all the paddings and spacings
+        self._plot_height = self.height
+        self._plot_height -= top_padding
+        self._plot_height -= t / 4 + b / 4
+
+        self._plot_width = self.width
+        self._plot_width -= 2 * side_padding
+        self._plot_width -= (self.n_bins - 2) * bar_spacing
+        self._plot_width -= l / 4 + r / 4
+
+        self.__layout = QGraphicsLinearLayout(Qt.Horizontal, self)
+        self.__layout.setContentsMargins(
+            side_padding + r / 2,
+            top_padding + t / 2,
+            side_padding + l / 2,
+            b / 2
+        )
+        self.__layout.setSpacing(bar_spacing)
+
+        self.edges, self.distributions = self._histogram()
+
+        self._draw_histogram()
+
+    def _get_histogram_edges(self):
+        """Get the edges in the histogram based on the attribute type.
+        
+        In case of a continuous variable, we split the variable range into
+        n bins. In case of a discrete variable, bins don't make sense, so we
+        just return the attribute values.
+        
+        This will return the staring and ending edge, not just the edges in
+        between (in the case of a continuous variable).
+
+        Returns
+        -------
+        np.ndarray
+        
+        """
+        if self.attribute.is_discrete:
+            return np.array([self.attribute.to_val(v) for v in self.attribute.values])
+        else:
+            edges = np.linspace(ut.nanmin(self.x), ut.nanmax(self.x), self.n_bins)
+            edge_diff = edges[1] - edges[0]
+            return np.hstack((edges, [edges[-1] + edge_diff]))
+
+    def _get_bin_distributions(self, bin_indices):
+        """Compute the distribution of instances within bins.
+
+        Parameters
+        ----------
+        bin_indices : np.ndarray
+            An array with same shape as `x` but containing the bin index of the
+            instance.
+
+        Returns
+        -------
+        np.ndarray
+            A 2d array; the first dimension represents different bins, the
+            second - the counts of different target values.
+
+        """
+        if self.target_var and self.target_var.is_discrete:
+            y = self.y
+            # TODO This probably also isn't the best handling of sparse data...
+            if sp.issparse(y):
+                y = np.squeeze(np.array(y.todense()))
+            y = one_hot(y)
+            bins = np.arange(self.n_bins)[:, np.newaxis]
+            mask = bin_indices == bins
+            distributions = np.zeros((self.n_bins, y.shape[1]))
+            for bin_idx in range(self.n_bins):
+                distributions[bin_idx] = y[mask[bin_idx]].sum(axis=0)
+        else:
+            distributions, _ = ut.bincount(bin_indices.astype(np.int64))
+            # To keep things consistent across different variable types, we
+            # want to return a 2d array where the first dim represent different
+            # bins, and the second the distributions.
+            distributions = distributions[:, np.newaxis]
+
+        return distributions
+
+    def _histogram(self):
+        edges = self._get_histogram_edges()
+
+        if self.attribute.is_discrete:
+            bin_indices = self.x
+            # TODO It probably isn't a very good idea to convert a sparse row
+            # to a dense array... Converts sparse to 1d numpy array
+            if sp.issparse(bin_indices):
+                bin_indices = np.squeeze(np.asarray(
+                    bin_indices.todense(), dtype=np.int64
+                ))
+        elif self.attribute.is_continuous:
+            # TODO: Digitize throws nans into first bin. This is incorrect.
+            bin_indices = ut.digitize(self.x, bins=edges[1:-1]).flatten()
+
+        distributions = self._get_bin_distributions(bin_indices)
+
+        return edges, distributions
+
+    def _draw_histogram(self):
+        if self.distributions.ndim > 1:
+            largest_bin_count = self.distributions.sum(axis=1).max()
+        else:
+            largest_bin_count = self.distributions.max()
+
+        bar_size = self._plot_width / self.n_bins
+
+        for distr, bin_colors in zip(self.distributions, self._get_colors()):
+            bin_count = distr.sum()
+            bar_height = bin_count / largest_bin_count * self._plot_height
+
+            bar_layout = QGraphicsLinearLayout(Qt.Vertical)
+            bar_layout.setSpacing(0)
+            bar_layout.addStretch()
+            self.__layout.addItem(bar_layout)
+
+            bar = ProportionalBarItem(
+                distribution=distr, colors=bin_colors, height=bar_height,
+                bar_size=bar_size,
+            )
+            bar_layout.addItem(bar)
+
+        self.layout()
+
+    def _get_colors(self):
+        """Compute colors for different kinds of histograms."""
+        if self.target_var and self.target_var.is_discrete:
+            colors = [[QColor(*color) for color in self.target_var.colors]] * self.n_bins
+
+        elif self.target_var and self.target_var.is_continuous:
+            palette = ContinuousPaletteGenerator(*self.target_var.colors)
+
+            bins = np.arange(self.n_bins)[:, np.newaxis]
+            edges = self.edges if self.attribute.is_discrete else self.edges[1:-1]
+            bin_indices = ut.digitize(self.x, bins=edges)
+            mask = bin_indices == bins
+
+            colors = []
+            for bin_idx in range(self.n_bins):
+                mean = ut.nanmean(self.y[mask[bin_idx]], axis=0) / self.y.max()
+                colors.append([palette[mean]])
+
+        else:
+            colors = [[QColor('#ccc')]] * self.n_bins
+
+        return colors
+
+    def boundingRect(self):
+        return QRectF(0, 0, self.width, self.height)
+
+    def sizeHint(self, which, constraint):
+        return QSizeF(self.width, self.height)
+
+    def sizePolicy(self):
+        return QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+
+if __name__ == '__main__':
+    import sys
+    from Orange.data.table import Table
+    from AnyQt.QtWidgets import QGraphicsView, QGraphicsScene, QApplication, \
+        QWidget
+
+    app = QApplication(sys.argv)
+    widget = QWidget()
+    widget.resize(500, 300)
+    scene = QGraphicsScene(widget)
+    view = QGraphicsView(scene, widget)
+    dataset = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
+    histogram = Histogram(
+        dataset, variable=0, height=300, width=500, n_bins=20, bar_spacing=2,
+        border=(0, 0, 5, 0), border_color='#000', class_index=0,
+    )
+    scene.addItem(histogram)
+
+    widget.show()
+    app.exec_()

--- a/orangecontrib/prototypes/widgets/utils/histogram.py
+++ b/orangecontrib/prototypes/widgets/utils/histogram.py
@@ -122,7 +122,7 @@ class Histogram(QGraphicsWidget):
 
     def __init__(self, data, variable, parent=None, height=200,
                  width=300, side_padding=5, top_padding=20, bar_spacing=4,
-                 border=0, border_color=None, class_index=None, n_bins=10):
+                 border=0, border_color=None, color_attribute=None, n_bins=10):
         super().__init__(parent)
         self.height, self.width = height, width
         self.padding = side_padding
@@ -148,12 +148,10 @@ class Histogram(QGraphicsWidget):
                 self.n_bins = min(max(2, num_unique), n_bins)
 
         # Handle target variable index
-        self.class_index = class_index
-        if self.class_index is not None:
-            assert 0 <= class_index < len(data.domain.class_vars), \
-                'Target variable `%d` out of range!' % class_index
-            self.target_var = data.domain.class_vars[class_index]
-            self.y = data.Y[:, class_index] if data.Y.ndim > 1 else data.Y
+        self.color_attribute = color_attribute
+        if self.color_attribute is not None:
+            self.target_var = data.domain[color_attribute]
+            self.y = data.get_column_view(color_attribute)[0]
         else:
             self.target_var, self.y = None, None
 
@@ -356,7 +354,7 @@ if __name__ == '__main__':
     dataset = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
     histogram = Histogram(
         dataset, variable=0, height=300, width=500, n_bins=20, bar_spacing=2,
-        border=(0, 0, 5, 0), border_color='#000', class_index=0,
+        border=(0, 0, 5, 0), border_color='#000', color_attribute='iris',
     )
     scene.addItem(histogram)
 


### PR DESCRIPTION
Show basic statistics for every feature.

Features of note:
- Widget is usable with large datasets (means, vars and missing are computed on init, hisograms are computed and drawn as needed and cached) 
- Histograms keep their aspect ratio as the widget resizes (however, this ratio is ignored if the height is too small).
- Dropdown to enable coloring by any target variable, or disable coloring entirely.
- Filter textbox for variable names
- Sparse support

Todo:
- Sorting (currently uses slow `QSortFilterProxyModel`), special sorting by variable type, special sorting by first and second moment
- Implement report
- Attribute selection sends dataset with these attributes to output.

Current state (_housing_ and _GDS1615_, respectively):
![](https://i.gyazo.com/58f31ba313a6f9043ed55880c989d8e7.png)
![](https://i.gyazo.com/87e2880ad194e2e8211a0cd6e3bb225c.png)