### PR TITLE
Data sets: Right-align sizes, Change button text

### DIFF
--- a/orangecontrib/prototypes/widgets/owdatasets.py
+++ b/orangecontrib/prototypes/widgets/owdatasets.py
@@ -80,6 +80,7 @@ class SizeDelegate(QStyledItemDelegate):
         value = index.data(Qt.DisplayRole)
         if isinstance(value, numbers.Integral):
             option.text = sizeformat(int(value))
+            option.displayAlignment = Qt.AlignRight | Qt.AlignVCenter
 
 
 class NumericalDelegate(QStyledItemDelegate):
@@ -154,7 +155,7 @@ class OWDataSets(widget.OWWidget):
         )
         self.mainArea.layout().addWidget(self.splitter)
         self.controlArea.layout().addStretch(10)
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Commit")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Data")
 
         model = QStandardItemModel(self)
         model.setHorizontalHeaderLabels(HEADER)


### PR DESCRIPTION
I think the sizes are now more readable.

"Send data" is probably better than "Commit". Is it? Better ideas? @ajdapretnar?

I cannot not comment on this: the widget is written in @ales-erjavec's handwriting. It's great. None of us comes close to this.