### PR TITLE
[FIX] Freeviz: mdsplotutils -> Mdsplotutils

### DIFF
--- a/orangecontrib/prototypes/widgets/owfreeviz.py
+++ b/orangecontrib/prototypes/widgets/owfreeviz.py
@@ -23,7 +23,7 @@ from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
 from Orange.widgets.utils.plot import OWPlotGUI
 from Orange.widgets.visualize import owlinearprojection as linproj
-from Orange.widgets.unsupervised.owmds import mdsplotutils as plotutils
+from Orange.widgets.unsupervised.owmds import Mdsplotutils as plotutils
 
 from orangecontrib.prototypes.projection.freeviz import freeviz
 from orangecontrib.prototypes.widgets.utils.axisitem import AxisItem


### PR DESCRIPTION
Freeviz does not work since Orange 3.4.4.

Error caused by 
https://github.com/biolab/orange3/commit/7ec9a6d2753c4567d0ad0851aa294d3b6d58cc3a