### PR TITLE
[ENH] Show result in Contingency Table widget

### DIFF
--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -2,7 +2,7 @@ import unicodedata
 from math import isnan, isinf, sqrt, pi
 
 from AnyQt.QtCore import Qt, QItemSelection, QItemSelectionModel
-from AnyQt.QtGui import QStandardItem, QColor, QFont, QBrush
+from AnyQt.QtGui import QStandardItem, QColor, QFont, QBrush, QPainter
 from AnyQt.QtWidgets import QTableView, QSizePolicy, QHeaderView, QStyledItemDelegate
 from Orange.widgets import gui
 
@@ -70,6 +70,7 @@ class CircleItemDelegate(BorderedItemDelegate, gui.VerticalItemDelegate):
             radius = max(1, max_radius*sqrt(area/pi))
             painter.setPen(Qt.transparent)
             painter.setBrush(Qt.blue)
+            painter.setRenderHint(QPainter.Antialiasing)
             painter.drawEllipse(rect.center(), radius, radius)
         else:
             BorderedItemDelegate.paint(self, painter, option, index)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -56,6 +56,8 @@ class ContingencyTable(QTableView):
         self.parent = parent
         self.tablemodel = tablemodel
 
+        self.corner_string = unicodedata.lookup("N-ARY SUMMATION")
+
         self.setModel(self.tablemodel)
         self.horizontalHeader().hide()
         self.verticalHeader().hide()
@@ -93,26 +95,21 @@ class ContingencyTable(QTableView):
     def _set_item(self, i, j, item):
         self.tablemodel.setItem(i, j, item)
 
-    def initialize(self, *,
-                   variablev=None, variableh=None,
-                   classesv=None, classesh=None, headerh=None, headerv=None,
-                   corner_string=None):
-        if variablev is not None:
-            self.classesv = variablev.values
-            self.headerv = variablev.name
-        if variableh is not None:
-            self.classesh = variableh.values
-            self.headerh = variableh.name
-        if classesv is not None:
-            self.classesv = classesv
-        if classesh is not None:
-            self.classesh = classesh
-        if headerv is not None:
-            self.headerv = headerv
-        if headerh is not None:
-            self.headerh = headerh
-        if corner_string is None:
-            corner_string = unicodedata.lookup("N-ARY SUMMATION")
+    def set_variables(self, variablev, variableh):
+        self.classesv = variablev.values
+        self.classesh = variableh.values
+        self.headerv = variablev.name
+        self.headerh = variableh.name
+        self.initialize()
+
+    def set_headers(self, classesv, classesh, headerv=None, headerh=None):
+        self.classesv = classesv
+        self.classesh = classesh
+        self.headerv = headerv
+        self.headerh = headerh
+        self.initialize()
+
+    def initialize(self):
         assert self.classesv is not None and self.classesh is not None
 
         item = self._item(0, 2)
@@ -140,8 +137,8 @@ class ContingencyTable(QTableView):
                 item.setFlags(Qt.NoItemFlags)
                 self._set_item(i, j, item)
 
-        for headers, ix in ((self.classesv + [corner_string], lambda p: (p + 2, 1)),
-                            (self.classesh + [corner_string], lambda p: (1, p + 2))):
+        for headers, ix in ((self.classesv + [self.corner_string], lambda p: (p + 2, 1)),
+                            (self.classesh + [self.corner_string], lambda p: (1, p + 2))):
             for p, label in enumerate(headers):
                 i, j = ix(p)
                 item = self._item(i, j)
@@ -157,7 +154,7 @@ class ContingencyTable(QTableView):
                 self._set_item(i, j, item)
 
         hor_header = self.horizontalHeader()
-        if len(' '.join(self.classesh + [corner_string])) < 120:
+        if len(' '.join(self.classesh + [self.corner_string])) < 120:
             hor_header.setSectionResizeMode(QHeaderView.ResizeToContents)
         else:
             hor_header.setDefaultSectionSize(60)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -63,7 +63,7 @@ class CircleItemDelegate(BorderedItemDelegate, gui.VerticalItemDelegate):
             gui.VerticalItemDelegate.paint(self, painter, option, index)
         elif index.column() == 1:
             BorderedItemDelegate.paint(self, painter, option, index)
-        elif 2 <= index.row() and 2 <= index.column() and area and 0 <= area <= 1:
+        elif 2 <= index.row() and 2 <= index.column() and area is not None and 0 <= area <= 1:
             QStyledItemDelegate.paint(self, painter, option, index)
             rect = option.rect
             max_radius = 20

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -51,6 +51,8 @@ class ContingencyTable(QTableView):
 
         self.classesv = None
         self.classesh = None
+        self.headerv = None
+        self.headerh = None
         self.parent = parent
         self.tablemodel = tablemodel
 
@@ -91,22 +93,36 @@ class ContingencyTable(QTableView):
     def _set_item(self, i, j, item):
         self.tablemodel.setItem(i, j, item)
 
-    def initialize(self, classesv, classesh=None, corner_string=None):
-        # Maybe merge with __init__.
-        self.classesv = classesv
-        self.classesh = classesh or self.classesv
+    def initialize(self, *,
+                   variablev=None, variableh=None,
+                   classesv=None, classesh=None, headerh=None, headerv=None,
+                   corner_string=None):
+        if variablev is not None:
+            self.classesv = variablev.values
+            self.headerv = variablev.name
+        if variableh is not None:
+            self.classesh = variableh.values
+            self.headerh = variableh.name
+        if classesv is not None:
+            self.classesv = classesv
+        if classesh is not None:
+            self.classesh = classesh
+        if headerv is not None:
+            self.headerv = headerv
+        if headerh is not None:
+            self.headerh = headerh
         if corner_string is None:
             corner_string = unicodedata.lookup("N-ARY SUMMATION")
+        assert self.classesv is not None and self.classesh is not None
 
-        # TODO: Change "Predicted" and "Actual" to attribute names when headersh isn't None.
         item = self._item(0, 2)
-        item.setData("Predicted", Qt.DisplayRole)
+        item.setData(self.headerh, Qt.DisplayRole)
         item.setTextAlignment(Qt.AlignCenter)
         item.setFlags(Qt.NoItemFlags)
 
         self._set_item(0, 2, item)
         item = self._item(2, 0)
-        item.setData("Actual", Qt.DisplayRole)
+        item.setData(self.headerv, Qt.DisplayRole)
         item.setTextAlignment(Qt.AlignHCenter | Qt.AlignBottom)
         item.setFlags(Qt.NoItemFlags)
         self.setItemDelegateForColumn(0, gui.VerticalItemDelegate())

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -9,7 +9,7 @@ from Orange.widgets import gui
 BorderRole = next(gui.OrangeUserRole)
 BorderColorRole = next(gui.OrangeUserRole)
 
-CircleArea = next(gui.OrangeUserRole)
+CircleAreaRole = next(gui.OrangeUserRole)
 
 
 class BorderedItemDelegate(QStyledItemDelegate):
@@ -47,24 +47,38 @@ class BorderedItemDelegate(QStyledItemDelegate):
 
 
 class CircleItemDelegate(BorderedItemDelegate, gui.VerticalItemDelegate):
+    """
+    Item delegate for display with circles. It switches between orienting
+    text vertically, painting borders, and drawing circles depending
+    on indices.
+
+    Role `CircleAreaRole` should be a float between 0 and 1 (inclusive) and
+    represents area of a circle.
+    """
     def sizeHint(self, option, index):
+        """
+        Overloads sizeHint and provides sizeHint for vertical text, cell with
+        borders, or circles depending on indices.
+        """
         if index.column() == 0 or index.row() == 1:
             return gui.VerticalItemDelegate.sizeHint(self, option, index)
-        elif index.column() == 1:
+        elif index.column() == 1 or index.row() == 0:
             return BorderedItemDelegate.sizeHint(self, option, index)
-        elif 2 <= index.row() and 2 <= index.column():
-            return QStyledItemDelegate.sizeHint(self, option, index)
         else:
-            return BorderedItemDelegate.sizeHint(self, option, index)
+            return QStyledItemDelegate.sizeHint(self, option, index)
 
     def paint(self, painter, option, index):
-        area = index.data(CircleArea)
+        """
+        Overloads paint and switches between orienting text vertically,
+        painting borders, and drawing circles depending on indices.
+        """
         if index.column() == 0 or index.row() == 1:
             gui.VerticalItemDelegate.paint(self, painter, option, index)
-        elif index.column() == 1:
+        elif index.column() == 1 or index.row() == 0:
             BorderedItemDelegate.paint(self, painter, option, index)
-        elif 2 <= index.row() and 2 <= index.column() and area is not None and 0 <= area <= 1:
+        else:
             QStyledItemDelegate.paint(self, painter, option, index)
+            area = index.data(CircleAreaRole)
             rect = option.rect
             max_radius = 20
             radius = max(1, max_radius*sqrt(area/pi))
@@ -72,8 +86,6 @@ class CircleItemDelegate(BorderedItemDelegate, gui.VerticalItemDelegate):
             painter.setBrush(Qt.blue)
             painter.setRenderHint(QPainter.Antialiasing)
             painter.drawEllipse(rect.center(), radius, radius)
-        else:
-            BorderedItemDelegate.paint(self, painter, option, index)
 
 
 class ContingencyTable(QTableView):
@@ -105,6 +117,7 @@ class ContingencyTable(QTableView):
     def __init__(self, parent):
         super().__init__(editTriggers=QTableView.NoEditTriggers)
 
+        self.bold_headers = None
         self.circles = False
         self.classesv = None
         self.classesh = None
@@ -126,6 +139,10 @@ class ContingencyTable(QTableView):
 
     def mouseReleaseEvent(self, e):
         super().mouseReleaseEvent(e)
+        self.parent._invalidate()
+
+    def keyPressEvent(self, event):
+        super().keyPressEvent(event)
         self.parent._invalidate()
 
     def _cell_clicked(self, model_index):
@@ -192,21 +209,10 @@ class ContingencyTable(QTableView):
         self.headerh = headerh
         self.initialize(**kwargs)
 
-    def initialize(self, circles=False, bold_headers=True):
+    def _style_cells(self):
         """
-        Initializes table structure. Class headers must be set beforehand.
-
-        Parameters
-        ----------
-        circles : :obj:`bool`, optional
-            Turns on circle display. All table values should be between 0 and 1 (inclusive). Defaults to False.
-        bold_headers : :obj:`bool`, optional
-            Whether the headers are bold or not. Defaults to True.
+        Style all cells.
         """
-        assert self.classesv is not None and self.classesh is not None
-
-        self.circles = circles
-
         if self.circles:
             self.setItemDelegate(CircleItemDelegate(Qt.white))
         else:
@@ -226,15 +232,19 @@ class ContingencyTable(QTableView):
         self.setSpan(0, 2, 1, len(self.classesh)+1)
         self.setSpan(2, 0, len(self.classesv)+1, 1)
 
-        font = self.tablemodel.invisibleRootItem().font()
-        bold_font = QFont(font)
-        bold_font.setBold(True)
-
         for i in (0, 1):
             for j in (0, 1):
                 item = self._item(i, j)
                 item.setFlags(Qt.NoItemFlags)
                 self._set_item(i, j, item)
+
+    def _initialize_headers(self):
+        """
+        Fill headers with content and style them.
+        """
+        font = self.tablemodel.invisibleRootItem().font()
+        bold_font = QFont(font)
+        bold_font.setBold(True)
 
         for headers, ix in ((self.classesv + [self.corner_string], lambda p: (p + 2, 1)),
                             (self.classesh + [self.corner_string], lambda p: (1, p + 2))):
@@ -242,7 +252,7 @@ class ContingencyTable(QTableView):
                 i, j = ix(p)
                 item = self._item(i, j)
                 item.setData(label, Qt.DisplayRole)
-                if bold_headers:
+                if self.bold_headers:
                     item.setFont(bold_font)
                 if not (i == 1 and self.circles):
                     item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
@@ -254,6 +264,10 @@ class ContingencyTable(QTableView):
                     item.setData("", BorderRole)
                 self._set_item(i, j, item)
 
+    def _resize(self):
+        """
+        Resize table to fit new contents and style.
+        """
         if self.circles:
             self.resizeRowToContents(1)
             self.horizontalHeader().setDefaultSectionSize(self.rowHeight(2))
@@ -267,6 +281,26 @@ class ContingencyTable(QTableView):
                 self.horizontalHeader().setDefaultSectionSize(60)
             self.tablemodel.setRowCount(len(self.classesv) + 3)
             self.tablemodel.setColumnCount(len(self.classesh) + 3)
+
+    def initialize(self, circles=False, bold_headers=True):
+        """
+        Initializes table structure. Class headers must be set beforehand.
+
+        Parameters
+        ----------
+        circles : :obj:`bool`, optional
+            Turns on circle display. All table values should be between 0 and 1 (inclusive). Defaults to False.
+        bold_headers : :obj:`bool`, optional
+            Whether the headers are bold or not. Defaults to True.
+        """
+        assert self.classesv is not None and self.classesh is not None
+
+        self.circles = circles
+        self.bold_headers = bold_headers
+
+        self._style_cells()
+        self._initialize_headers()
+        self._resize()
 
     def get_selection(self):
         """
@@ -296,6 +330,77 @@ class ContingencyTable(QTableView):
         self.selectionModel().select(
             selection, QItemSelectionModel.ClearAndSelect)
 
+    def _set_sums(self, colsum, rowsum):
+        """
+        Set content of cells on bottom and right edge.
+
+        Parameters
+        ----------
+        colsum : numpy.array
+            Content of cells on bottom edge.
+        rowsum : numpy.array
+            Content of cells on right edge.
+        """
+        bold_font = self.tablemodel.invisibleRootItem().font()
+        bold_font.setBold(True)
+
+        def _sum_item(value, border=""):
+            item = QStandardItem()
+            item.setData(value, Qt.DisplayRole)
+            item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+            item.setFlags(Qt.ItemIsEnabled)
+            item.setFont(bold_font)
+            item.setData(border, BorderRole)
+            item.setData(QColor(192, 192, 192), BorderColorRole)
+            return item
+
+        for i in range(len(self.classesh)):
+            self._set_item(len(self.classesv) + 2, i + 2, _sum_item(int(colsum[i]), "t"))
+        for i in range(len(self.classesv)):
+            self._set_item(i + 2, len(self.classesh) + 2, _sum_item(int(rowsum[i]), "l"))
+        self._set_item(len(self.classesv) + 2, len(self.classesh) + 2, _sum_item(int(rowsum.sum())))
+
+    def _set_values(self, matrix, colors, formatstr, tooltip):
+        """
+        Set content of cells which aren't headers and don't represent aggregate values.
+
+        Parameters
+        ----------
+        matrix : numpy.array
+            2D array to be set as data.
+        colors : :obj:`numpy.array`
+            2D array with color values.
+        formatstr : :obj:`str`, optional
+            Format string for cell data.
+        tooltip : :obj:`(int, int) -> str`
+            Function which takes vertical index and horizontal index as arguments and returns
+            desired tooltip as a string.
+        """
+        def _isinvalid(x):
+            return isnan(x) or isinf(x)
+
+        for i in range(len(self.classesv)):
+            for j in range(len(self.classesh)):
+                val = matrix[i, j]
+                col_val = float('nan') if colors is None else colors[i, j]
+                item = QStandardItem()
+                if self.circles:
+                    item.setData(val, CircleAreaRole)
+                else:
+                    item.setData(
+                        "NA" if _isinvalid(val) else formatstr.format(val),
+                        Qt.DisplayRole)
+                    bkcolor = QColor.fromHsl(
+                        [0, 240][i == j], 160,
+                        255 if _isinvalid(col_val) else int(255 - 30 * col_val))
+                    item.setData(QBrush(bkcolor), Qt.BackgroundRole)
+                item.setData("trbl", BorderRole)
+                if tooltip is not None:
+                    item.setToolTip(tooltip(i, j))
+                item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+                item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+                self._set_item(i + 2, j + 2, item)
+
     def update_table(self, matrix, colsum=None, rowsum=None, colors=None, formatstr="{}", tooltip=None):
         """
         Sets ``matrix`` as data of the table.
@@ -316,58 +421,15 @@ class ContingencyTable(QTableView):
             Function which takes vertical index and horizontal index as arguments and returns
             desired tooltip as a string. Defaults to no tooltips.
         """
-        def _isinvalid(x):
-            return isnan(x) or isinf(x)
+        selected_indexes = self.get_selection()
 
+        self._set_values(matrix, colors, formatstr, tooltip)
         if not self.circles:
             if colsum is None:
                 colsum = matrix.sum(axis=0)
             if rowsum is None:
                 rowsum = matrix.sum(axis=1)
-
-        selected_indexes = self.get_selection()
-
-        for i in range(len(self.classesv)):
-            for j in range(len(self.classesh)):
-                val = matrix[i, j]
-                col_val = float('nan') if colors is None else colors[i, j]
-                item = QStandardItem()
-                if self.circles:
-                    item.setData(val, CircleArea)
-                else:
-                    item.setData(
-                        "NA" if _isinvalid(val) else formatstr.format(val),
-                        Qt.DisplayRole)
-                    bkcolor = QColor.fromHsl(
-                        [0, 240][i == j], 160,
-                        255 if _isinvalid(col_val) else int(255 - 30 * col_val))
-                    item.setData(QBrush(bkcolor), Qt.BackgroundRole)
-                item.setData("trbl", BorderRole)
-                if tooltip is not None:
-                    item.setToolTip(tooltip(i, j))
-                item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
-                item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
-                self._set_item(i + 2, j + 2, item)
-
-        if not self.circles:
-            bold_font = self.tablemodel.invisibleRootItem().font()
-            bold_font.setBold(True)
-
-            def _sum_item(value, border=""):
-                item = QStandardItem()
-                item.setData(value, Qt.DisplayRole)
-                item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
-                item.setFlags(Qt.ItemIsEnabled)
-                item.setFont(bold_font)
-                item.setData(border, BorderRole)
-                item.setData(QColor(192, 192, 192), BorderColorRole)
-                return item
-
-            for i in range(len(self.classesh)):
-                self._set_item(len(self.classesv) + 2, i + 2, _sum_item(int(colsum[i]), "t"))
-            for i in range(len(self.classesv)):
-                self._set_item(i + 2, len(self.classesh) + 2, _sum_item(int(rowsum[i]), "l"))
-            self._set_item(len(self.classesv) + 2, len(self.classesh) + 2, _sum_item(int(rowsum.sum())))
+            self._set_sums(colsum, rowsum)
 
         self.set_selection(selected_indexes)
 

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -160,7 +160,7 @@ class ContingencyTable(QTableView):
         self.selectionModel().select(
             selection, QItemSelectionModel.ClearAndSelect)
 
-    def update_table(self, matrix, colsum=None, rowsum=None, colors=None, formatstr="{}"):
+    def update_table(self, matrix, colsum=None, rowsum=None, colors=None, formatstr="{}", tooltip=None):
         def _isinvalid(x):
             return isnan(x) or isinf(x)
 
@@ -184,9 +184,8 @@ class ContingencyTable(QTableView):
                     255 if _isinvalid(col_val) else int(255 - 30 * col_val))
                 item.setData(QBrush(bkcolor), Qt.BackgroundRole)
                 item.setData("trbl", BorderRole)
-                # TODO: Make tooltips appropriate.
-                item.setToolTip("actual: {}\npredicted: {}".format(
-                    self.classesv[i], self.classesh[j]))
+                if tooltip is not None:
+                    item.setToolTip(tooltip(self.classesv[i], self.classesh[j]))
                 item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
                 item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
                 self._set_item(i + 2, j + 2, item)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -71,14 +71,15 @@ class ContingencyTable(QTableView):
         if not i or not j:
             return
         n = self.tablemodel.rowCount()
+        m = self.tablemodel.columnCount()
         index = self.tablemodel.index
         selection = None
-        if i == j == 1 or i == j == n - 1:
-            selection = QItemSelection(index(2, 2), index(n - 1, n - 1))
+        if i == j == 1 or i == n - 1 and j == m - 1:
+            selection = QItemSelection(index(2, 2), index(n - 1, m - 1))
         elif i in (1, n - 1):
             selection = QItemSelection(index(2, j), index(n - 1, j))
-        elif j in (1, n - 1):
-            selection = QItemSelection(index(i, 2), index(i, n - 1))
+        elif j in (1, m - 1):
+            selection = QItemSelection(index(i, 2), index(i, m - 1))
 
         if selection is not None:
             self.selectionModel().select(
@@ -147,6 +148,18 @@ class ContingencyTable(QTableView):
         self.tablemodel.setRowCount(len(self.classesv) + 3)
         self.tablemodel.setColumnCount(len(self.classesh) + 3)
 
+    def get_selection(self):
+        return {(ind.row() - 2, ind.column() - 2) for ind in self.selectedIndexes()}
+
+    def set_selection(self, indexes):
+        selection = QItemSelection()
+        index = self.model().index
+        for row, col in indexes:
+            sel = index(row + 2, col + 2)
+            selection.select(sel, sel)
+        self.selectionModel().select(
+            selection, QItemSelectionModel.ClearAndSelect)
+
     def update_table(self, matrix, colsum=None, rowsum=None, colors=None, formatstr="{}"):
         def _isinvalid(x):
             return isnan(x) or isinf(x)
@@ -155,6 +168,8 @@ class ContingencyTable(QTableView):
             colsum = matrix.sum(axis=0)
         if rowsum is None:
             rowsum = matrix.sum(axis=1)
+
+        selected_indexes = {(ind.row() - 2, ind.column() - 2) for ind in self.selectedIndexes()}
 
         for i in range(len(self.classesv)):
             for j in range(len(self.classesh)):
@@ -194,3 +209,5 @@ class ContingencyTable(QTableView):
         for i in range(len(self.classesv)):
             self._set_item(i + 2, len(self.classesh) + 2, _sum_item(int(rowsum[i]), "l"))
         self._set_item(len(self.classesv) + 2, len(self.classesh) + 2, _sum_item(int(rowsum.sum())))
+
+        self.set_selection(selected_indexes)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -63,9 +63,9 @@ class ContingencyTable(QTableView):
         self.setItemDelegate(BorderedItemDelegate(Qt.white))
         self.setSizePolicy(QSizePolicy.MinimumExpanding,
                            QSizePolicy.MinimumExpanding)
-        self.clicked.connect(self.cell_clicked)
+        self.clicked.connect(self._cell_clicked)
 
-    def cell_clicked(self, model_index):
+    def _cell_clicked(self, model_index):
         """Handle cell click event"""
         i, j = model_index.row(), model_index.column()
         if not i or not j:

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -59,13 +59,13 @@ class ContingencyTable(QTableView):
     Attributes
     ----------
     classesv : :obj:`list` of :obj:`str`
-        Class vertical headers.
+        Vertical class headers.
     classesh : :obj:`list` of :obj:`str`
-        Class horizontal headers.
+        Horizontal class headers.
     headerv : :obj:`str`, optional
-        Top vertical header.
+        Vertical top header.
     headerh : :obj:`str`, optional
-        Top horizontal header.
+        Horizontal top header.
     corner_string : str
         String that is top right and bottom left corner of the table.
         Default is ``unicodedata.lookup("N-ARY SUMMATION")``.
@@ -144,13 +144,13 @@ class ContingencyTable(QTableView):
         Parameters
         ----------
         classesv : :obj:`list` of :obj:`str`
-            Class vertical headers.
+            Vertical class headers.
         classesh : :obj:`list` of :obj:`str`
-            Class horizontal headers.
+            Horizontal class headers.
         headerv : :obj:`str`, optional
-            Top vertical header.
+            Vertical top header.
         headerh : :obj:`str`, optional
-            Top horizontal header.
+            Horizontal top header.
         """
         self.classesv = classesv
         self.classesh = classesh

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -46,6 +46,31 @@ class BorderedItemDelegate(QStyledItemDelegate):
 
 
 class ContingencyTable(QTableView):
+    """
+    A contingency table widget which can be used wherever ``QTableView`` could be used.
+
+    Parameters
+    ----------
+    parent : Orange.widgets.widget.OWWidget as a
+        The containing widget to which the table is connected.
+    tablemodel : AnyQt.QtGui.QtStandardItemModel
+        The model in which table data will be stored.
+
+    Attributes
+    ----------
+    classesv : :obj:`list` of :obj:`str`
+        Class vertical headers.
+    classesh : :obj:`list` of :obj:`str`
+        Class horizontal headers.
+    headerv : :obj:`str`, optional
+        Top vertical header.
+    headerh : :obj:`str`, optional
+        Top horizontal header.
+    corner_string : str
+        String that is top right and bottom left corner of the table.
+        Default is ``unicodedata.lookup("N-ARY SUMMATION")``.
+    """
+
     def __init__(self, parent, tablemodel):
         super().__init__(editTriggers=QTableView.NoEditTriggers)
 
@@ -96,6 +121,16 @@ class ContingencyTable(QTableView):
         self.tablemodel.setItem(i, j, item)
 
     def set_variables(self, variablev, variableh):
+        """
+        Sets class headers and top headers and initializes table structure.
+
+        Parameters
+        ----------
+        variablev : Orange.data.variable.DiscreteVariable
+            Class headers are set to ``variablev.values``, top header is set to ``variablev.name``.
+        variableh : Orange.data.variable.DiscreteVariable
+            Class headers are set to ``variableh.values``, top header is set to ``variableh.name``.
+        """
         self.classesv = variablev.values
         self.classesh = variableh.values
         self.headerv = variablev.name
@@ -103,6 +138,20 @@ class ContingencyTable(QTableView):
         self.initialize()
 
     def set_headers(self, classesv, classesh, headerv=None, headerh=None):
+        """
+        Sets class headers and top headers and initializes table structure.
+
+        Parameters
+        ----------
+        classesv : :obj:`list` of :obj:`str`
+            Class vertical headers.
+        classesh : :obj:`list` of :obj:`str`
+            Class horizontal headers.
+        headerv : :obj:`str`, optional
+            Top vertical header.
+        headerh : :obj:`str`, optional
+            Top horizontal header.
+        """
         self.classesv = classesv
         self.classesh = classesh
         self.headerv = headerv
@@ -110,6 +159,9 @@ class ContingencyTable(QTableView):
         self.initialize()
 
     def initialize(self):
+        """
+        Initializes table structure. Class headers must be set beforehand.
+        """
         assert self.classesv is not None and self.classesh is not None
 
         item = self._item(0, 2)
@@ -162,9 +214,25 @@ class ContingencyTable(QTableView):
         self.tablemodel.setColumnCount(len(self.classesh) + 3)
 
     def get_selection(self):
+        """
+        Get indexes of selected cells.
+
+        Returns
+        -------
+        :obj:`set` of :obj:`tuple` of :obj:`int`
+            Set of pairs of indexes.
+        """
         return {(ind.row() - 2, ind.column() - 2) for ind in self.selectedIndexes()}
 
     def set_selection(self, indexes):
+        """
+        Set indexes of selected cells.
+
+        Parameters
+        ----------
+        indexes : :obj:`set` of :obj:`tuple` of :obj:`int`
+            Set of pairs of indexes.
+        """
         selection = QItemSelection()
         index = self.model().index
         for row, col in indexes:
@@ -174,6 +242,25 @@ class ContingencyTable(QTableView):
             selection, QItemSelectionModel.ClearAndSelect)
 
     def update_table(self, matrix, colsum=None, rowsum=None, colors=None, formatstr="{}", tooltip=None):
+        """
+        Sets ``matrix`` as data of the table.
+
+        Parameters
+        ----------
+        matrix : numpy.array
+            2D array to be set as data.
+        colsum : :obj:`numpy.array`, optional
+            1D optional array with aggregate values of columns, defaults to sum.
+        rowsum : :obj:`numpy.array`, optional
+            1D optional array with aggregate values of rows, defaults to sum.
+        colors : :obj:`numpy.array`, optional
+            2D array with color values, defaults to no color.
+        formatstr : :obj:`str`, optional
+            Format string for cell data, defaults to ``"{}"``.
+        tooltip : :obj:`(str, str) -> str`, optional
+            Function which takes vertical class and horizontal class (strings) as arguments and returns
+            desired tooltip as a string. Defaults to no tooltips.
+        """
         def _isinvalid(x):
             return isnan(x) or isinf(x)
 

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -364,3 +364,9 @@ class ContingencyTable(QTableView):
             self._set_item(len(self.classesv) + 2, len(self.classesh) + 2, _sum_item(int(rowsum.sum())))
 
         self.set_selection(selected_indexes)
+
+    def clear(self):
+        """
+        Clears the table.
+        """
+        self.tablemodel.clear()

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -76,8 +76,6 @@ class CircleItemDelegate(BorderedItemDelegate, gui.VerticalItemDelegate):
             BorderedItemDelegate.paint(self, painter, option, index)
 
 
-
-
 class ContingencyTable(QTableView):
     """
     A contingency table widget which can be used wherever ``QTableView`` could be used.
@@ -136,11 +134,11 @@ class ContingencyTable(QTableView):
         m = self.tablemodel.columnCount()
         index = self.tablemodel.index
         selection = None
-        if i == j == 1 or i == n - 1 and j == m - 1:
+        if i == j == 1 or not self.circles and i == n - 1 and j == m - 1:
             selection = QItemSelection(index(2, 2), index(n - 1, m - 1))
-        elif i in (1, n - 1):
+        elif i == 1 or not self.circles and i == n - 1:
             selection = QItemSelection(index(2, j), index(n - 1, j))
-        elif j in (1, m - 1):
+        elif j == 1 or not self.circles and j == m - 1:
             selection = QItemSelection(index(i, 2), index(i, m - 1))
 
         if selection is not None:

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -306,8 +306,8 @@ class ContingencyTable(QTableView):
             2D array with color values, defaults to no color.
         formatstr : :obj:`str`, optional
             Format string for cell data, defaults to ``"{}"``.
-        tooltip : :obj:`(str, str) -> str`, optional
-            Function which takes vertical class and horizontal class (strings) as arguments and returns
+        tooltip : :obj:`(int, int) -> str`, optional
+            Function which takes vertical index and horizontal index as arguments and returns
             desired tooltip as a string. Defaults to no tooltips.
         """
         def _isinvalid(x):
@@ -338,7 +338,7 @@ class ContingencyTable(QTableView):
                     item.setData(QBrush(bkcolor), Qt.BackgroundRole)
                 item.setData("trbl", BorderRole)
                 if tooltip is not None:
-                    item.setToolTip(tooltip(self.classesv[i], self.classesh[j]))
+                    item.setToolTip(tooltip(i, j))
                 item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
                 item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
                 self._set_item(i + 2, j + 2, item)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -119,11 +119,14 @@ class ContingencyTable(QTableView):
         self.horizontalHeader().hide()
         self.verticalHeader().hide()
         self.horizontalHeader().setMinimumSectionSize(60)
-        self.selectionModel().selectionChanged.connect(self.parent._invalidate)
         self.setShowGrid(False)
         self.setSizePolicy(QSizePolicy.MinimumExpanding,
                            QSizePolicy.MinimumExpanding)
         self.clicked.connect(self._cell_clicked)
+
+    def mouseReleaseEvent(self, e):
+        super().mouseReleaseEvent(e)
+        self.parent._invalidate()
 
     def _cell_clicked(self, model_index):
         """Handle cell click event"""
@@ -189,14 +192,16 @@ class ContingencyTable(QTableView):
         self.headerh = headerh
         self.initialize(**kwargs)
 
-    def initialize(self, circles=False):
+    def initialize(self, circles=False, bold_headers=True):
         """
         Initializes table structure. Class headers must be set beforehand.
 
         Parameters
         ----------
         circles : :obj:`bool`, optional
-            Turns on circle display. All table values should be between 0 and 1 (inclusive).
+            Turns on circle display. All table values should be between 0 and 1 (inclusive). Defaults to False.
+        bold_headers : :obj:`bool`, optional
+            Whether the headers are bold or not. Defaults to True.
         """
         assert self.classesv is not None and self.classesh is not None
 
@@ -237,7 +242,8 @@ class ContingencyTable(QTableView):
                 i, j = ix(p)
                 item = self._item(i, j)
                 item.setData(label, Qt.DisplayRole)
-                item.setFont(bold_font)
+                if bold_headers:
+                    item.setFont(bold_font)
                 if not (i == 1 and self.circles):
                     item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
                 item.setFlags(Qt.ItemIsEnabled)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -248,16 +248,17 @@ class ContingencyTable(QTableView):
                     item.setData("", BorderRole)
                 self._set_item(i, j, item)
 
-        hor_header = self.horizontalHeader()
-        if len(' '.join(self.classesh + [self.corner_string])) < 120:
-            hor_header.setSectionResizeMode(QHeaderView.ResizeToContents)
-        else:
-            hor_header.setDefaultSectionSize(60)
         if self.circles:
             self.resizeRowToContents(1)
+            self.horizontalHeader().setDefaultSectionSize(self.rowHeight(2))
+            self.resizeColumnToContents(1)
             self.tablemodel.setRowCount(len(self.classesv) + 2)
             self.tablemodel.setColumnCount(len(self.classesh) + 2)
         else:
+            if len(' '.join(self.classesh + [self.corner_string])) < 120:
+                self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+            else:
+                self.horizontalHeader().setDefaultSectionSize(60)
             self.tablemodel.setRowCount(len(self.classesv) + 3)
             self.tablemodel.setColumnCount(len(self.classesh) + 3)
 

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -94,10 +94,8 @@ class ContingencyTable(QTableView):
 
     Parameters
     ----------
-    parent : Orange.widgets.widget.OWWidget as a
+    parent : Orange.widgets.widget.OWWidget
         The containing widget to which the table is connected.
-    tablemodel : AnyQt.QtGui.QtStandardItemModel
-        The model in which table data will be stored.
 
     Attributes
     ----------

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -1,0 +1,123 @@
+from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QStandardItem, QColor, QFont
+from AnyQt.QtWidgets import QTableView, QSizePolicy, QHeaderView, QStyledItemDelegate
+from Orange.widgets import gui
+
+
+BorderRole = next(gui.OrangeUserRole)
+BorderColorRole = next(gui.OrangeUserRole)
+
+
+class BorderedItemDelegate(QStyledItemDelegate):
+    """Item delegate that paints border at the specified sides
+
+    Data for `BorderRole` is a string containing letters t, r, b and/or l,
+    which defines the sides at which the border is drawn.
+
+    Role `BorderColorRole` sets the color for the cell. If not color is given,
+    `self.color` is used as default.
+
+    Args:
+        color (QColor): default color (default default is black)
+    """
+    def __init__(self, color=Qt.black):
+        super().__init__()
+        self.color = color
+
+    def paint(self, painter, option, index):
+        """Overloads `paint` to draw borders"""
+        QStyledItemDelegate.paint(self, painter, option, index)
+        borders = index.data(BorderRole)
+        if borders:
+            color = index.data(BorderColorRole) or self.color
+            painter.save()
+            painter.setPen(color)
+            rect = option.rect
+            for side, p1, p2 in (("t", rect.topLeft(), rect.topRight()),
+                                 ("r", rect.topRight(), rect.bottomRight()),
+                                 ("b", rect.bottomLeft(), rect.bottomRight()),
+                                 ("l", rect.topLeft(), rect.bottomLeft())):
+                if side in borders:
+                    painter.drawLine(p1, p2)
+            painter.restore()
+
+
+class ContingencyTable(QTableView):
+    def __init__(self, parent, tablemodel, click_event=None):
+        super().__init__(editTriggers=QTableView.NoEditTriggers)
+
+        self.parent = parent
+        self.tablemodel = tablemodel
+
+        self.setModel(self.tablemodel)
+        self.horizontalHeader().hide()
+        self.verticalHeader().hide()
+        self.horizontalHeader().setMinimumSectionSize(60)
+        self.selectionModel().selectionChanged.connect(self.parent._invalidate)
+        self.setShowGrid(False)
+        self.setItemDelegate(BorderedItemDelegate(Qt.white))
+        self.setSizePolicy(QSizePolicy.MinimumExpanding,
+                           QSizePolicy.MinimumExpanding)
+        if click_event:
+            self.clicked.connect(click_event)
+
+    def _item(self, i, j):
+        return self.tablemodel.item(i, j) or QStandardItem()
+
+    def _set_item(self, i, j, item):
+        self.tablemodel.setItem(i, j, item)
+
+    def initialize(self, headersv, headersh=None):
+        # Maybe merge with __init__.
+        # Maybe add unicodedata.lookup("N-ARY SUMMATION") automatically.
+        headersh = headersh or headersv
+        nclassesv = len(headersv) - 1
+        nclassesh = len(headersh) - 1
+
+        # TODO: Change "Predicted" and "Actual" to attribute names when headersh isn't None.
+        item = self._item(0, 2)
+        item.setData("Predicted", Qt.DisplayRole)
+        item.setTextAlignment(Qt.AlignCenter)
+        item.setFlags(Qt.NoItemFlags)
+
+        self._set_item(0, 2, item)
+        item = self._item(2, 0)
+        item.setData("Actual", Qt.DisplayRole)
+        item.setTextAlignment(Qt.AlignHCenter | Qt.AlignBottom)
+        item.setFlags(Qt.NoItemFlags)
+        self.setItemDelegateForColumn(0, gui.VerticalItemDelegate())
+        self._set_item(2, 0, item)
+        self.setSpan(0, 2, 1, nclassesh)
+        self.setSpan(2, 0, nclassesv, 1)
+
+        font = self.tablemodel.invisibleRootItem().font()
+        bold_font = QFont(font)
+        bold_font.setBold(True)
+
+        for i in (0, 1):
+            for j in (0, 1):
+                item = self._item(i, j)
+                item.setFlags(Qt.NoItemFlags)
+                self._set_item(i, j, item)
+
+        for headers, nclasses, ix in ((headersv, nclassesv, lambda p: (p + 2, 1)),
+                                      (headersh, nclassesh, lambda p: (1, p + 2))):
+            for p, label in enumerate(headers):
+                i, j = ix(p)
+                item = self._item(i, j)
+                item.setData(label, Qt.DisplayRole)
+                item.setFont(bold_font)
+                item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+                item.setFlags(Qt.ItemIsEnabled)
+                if p < nclasses:
+                    item.setData("br"[j == 1], BorderRole)
+                    item.setData(QColor(192, 192, 192), BorderColorRole)
+                self._set_item(i, j, item)
+
+        hor_header = self.horizontalHeader()
+        if len(' '.join(headersh)) < 120:
+            hor_header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        else:
+            hor_header.setDefaultSectionSize(60)
+        self.tablemodel.setRowCount(nclassesv + 3)
+        self.tablemodel.setColumnCount(nclassesh + 3)

--- a/orangecontrib/prototypes/widgets/contingency_table.py
+++ b/orangecontrib/prototypes/widgets/contingency_table.py
@@ -2,7 +2,7 @@ import unicodedata
 from math import isnan, isinf, sqrt, pi
 
 from AnyQt.QtCore import Qt, QItemSelection, QItemSelectionModel
-from AnyQt.QtGui import QStandardItem, QColor, QFont, QBrush, QPainter
+from AnyQt.QtGui import QStandardItem, QColor, QFont, QBrush, QPainter, QStandardItemModel
 from AnyQt.QtWidgets import QTableView, QSizePolicy, QHeaderView, QStyledItemDelegate
 from Orange.widgets import gui
 
@@ -102,7 +102,7 @@ class ContingencyTable(QTableView):
         Default is ``unicodedata.lookup("N-ARY SUMMATION")``.
     """
 
-    def __init__(self, parent, tablemodel):
+    def __init__(self, parent):
         super().__init__(editTriggers=QTableView.NoEditTriggers)
 
         self.circles = False
@@ -111,10 +111,10 @@ class ContingencyTable(QTableView):
         self.headerv = None
         self.headerh = None
         self.parent = parent
-        self.tablemodel = tablemodel
 
         self.corner_string = unicodedata.lookup("N-ARY SUMMATION")
 
+        self.tablemodel = QStandardItemModel(self)
         self.setModel(self.tablemodel)
         self.horizontalHeader().hide()
         self.verticalHeader().hide()

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -1,0 +1,437 @@
+"""Confusion matrix widget"""
+
+import unicodedata
+from math import isnan, isinf
+
+import Orange
+import Orange.evaluation
+import numpy as np
+import sklearn.metrics as skl_metrics
+from AnyQt.QtCore import Qt, QSize, QItemSelectionModel, QItemSelection
+from AnyQt.QtGui import QBrush, QColor, QStandardItemModel, QStandardItem
+from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.annotated_data import (create_annotated_table,
+                                                 ANNOTATED_DATA_SIGNAL_NAME)
+from Orange.widgets.widget import Msg, Input, Output
+
+from orangecontrib.prototypes.widgets.contingency_table import ContingencyTable, BorderRole, BorderColorRole
+
+
+def confusion_matrix(res, index):
+    """
+    Compute confusion matrix
+
+    Args:
+        res (Orange.evaluation.Results): evaluation results
+        index (int): model index
+
+    Returns: Confusion matrix
+    """
+    labels = np.arange(len(res.domain.class_var.values))
+    if not res.actual.size:
+        # scikit-learn will not return an zero matrix
+        return np.zeros((len(labels), len(labels)))
+    else:
+        return skl_metrics.confusion_matrix(
+            res.actual, res.predicted[index], labels=labels)
+
+
+class OWConfusionMatrix(widget.OWWidget):
+    """Confusion matrix widget"""
+
+    name = "Confusion Matrix"
+    description = "Display a confusion matrix constructed from " \
+                  "the results of classifier evaluations."
+    icon = "icons/ConfusionMatrix.svg"
+    priority = 1001
+
+    class Inputs:
+        evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)
+
+    class Outputs:
+        selected_data = Output("Selected Data", Orange.data.Table, default=True)
+        annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Orange.data.Table)
+
+    quantities = ["Number of instances",
+                  "Proportion of predicted",
+                  "Proportion of actual"]
+
+    settings_version = 1
+    settingsHandler = settings.ClassValuesContextHandler()
+
+    selected_learner = settings.Setting([0], schema_only=True)
+    selection = settings.ContextSetting(set())
+    selected_quantity = settings.Setting(0)
+    append_predictions = settings.Setting(True)
+    append_probabilities = settings.Setting(False)
+    autocommit = settings.Setting(True)
+
+    UserAdviceMessages = [
+        widget.Message(
+            "Clicking on cells or in headers outputs the corresponding "
+            "data instances",
+            "click_cell")]
+
+    class Error(widget.OWWidget.Error):
+        no_regression = Msg("Confusion Matrix cannot show regression results.")
+        invalid_values = Msg("Evaluation Results input contains invalid values")
+
+    def __init__(self):
+        super().__init__()
+
+        self.data = None
+        self.results = None
+        self.learners = []
+        self.headers = []
+
+        self.learners_box = gui.listBox(
+            self.controlArea, self, "selected_learner", "learners", box=True,
+            callback=self._learner_changed
+        )
+
+        self.outputbox = gui.vBox(self.controlArea, "Output")
+        box = gui.hBox(self.outputbox)
+        gui.checkBox(box, self, "append_predictions",
+                     "Predictions", callback=self._invalidate)
+        gui.checkBox(box, self, "append_probabilities",
+                     "Probabilities",
+                     callback=self._invalidate)
+
+        gui.auto_commit(self.outputbox, self, "autocommit",
+                        "Send Selected", "Send Automatically", box=False)
+
+        self.mainArea.layout().setContentsMargins(0, 0, 0, 0)
+
+        box = gui.vBox(self.mainArea, box=True)
+
+        sbox = gui.hBox(box)
+        gui.rubber(sbox)
+        gui.comboBox(sbox, self, "selected_quantity",
+                     items=self.quantities, label="Show: ",
+                     orientation=Qt.Horizontal, callback=self._update)
+
+        self.tablemodel = QStandardItemModel(self)
+        view = self.tableview = ContingencyTable(self, self.tablemodel, self.cell_clicked)
+        box.layout().addWidget(view)
+
+        selbox = gui.hBox(box)
+        gui.button(selbox, self, "Select Correct",
+                   callback=self.select_correct, autoDefault=False)
+        gui.button(selbox, self, "Select Misclassified",
+                   callback=self.select_wrong, autoDefault=False)
+        gui.button(selbox, self, "Clear Selection",
+                   callback=self.select_none, autoDefault=False)
+
+    def sizeHint(self):
+        """Initial size"""
+        return QSize(750, 340)
+
+    def _item(self, i, j):
+        return self.tablemodel.item(i, j) or QStandardItem()
+
+    def _set_item(self, i, j, item):
+        self.tablemodel.setItem(i, j, item)
+
+    @Inputs.evaluation_results
+    def set_results(self, results):
+        """Set the input results."""
+
+        prev_sel_learner = self.selected_learner.copy()
+        self.clear()
+        self.warning()
+        self.closeContext()
+
+        data = None
+        if results is not None and results.data is not None:
+            data = results.data[results.row_indices]
+
+        if data is not None and not data.domain.has_discrete_class:
+            self.Error.no_regression()
+            data = results = None
+        else:
+            self.Error.no_regression.clear()
+
+        nan_values = False
+        if results is not None:
+            assert isinstance(results, Orange.evaluation.Results)
+            if np.any(np.isnan(results.actual)) or \
+                    np.any(np.isnan(results.predicted)):
+                # Error out here (could filter them out with a warning
+                # instead).
+                nan_values = True
+                results = data = None
+
+        if nan_values:
+            self.Error.invalid_values()
+        else:
+            self.Error.invalid_values.clear()
+
+        self.results = results
+        self.data = data
+
+        if data is not None:
+            class_values = data.domain.class_var.values
+        elif results is not None:
+            raise NotImplementedError
+
+        if results is None:
+            self.report_button.setDisabled(True)
+        else:
+            self.report_button.setDisabled(False)
+
+            nmodels = results.predicted.shape[0]
+            self.headers = class_values + \
+                           [unicodedata.lookup("N-ARY SUMMATION")]
+
+            # NOTE: The 'learner_names' is set in 'Test Learners' widget.
+            if hasattr(results, "learner_names"):
+                self.learners = results.learner_names
+            else:
+                self.learners = ["Learner #{}".format(i + 1)
+                                 for i in range(nmodels)]
+
+            self.tableview.initialize(self.headers)
+            self.openContext(data.domain.class_var)
+            if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
+                if self.learners:
+                    self.selected_learner[:] = [0]
+            else:
+                self.selected_learner[:] = prev_sel_learner
+            self._update()
+            self._set_selection()
+            self.unconditional_commit()
+
+    def clear(self):
+        """Reset the widget, clear controls"""
+        self.results = None
+        self.data = None
+        self.tablemodel.clear()
+        self.headers = []
+        # Clear learners last. This action will invoke `_learner_changed`
+        self.learners = []
+
+    def select_correct(self):
+        """Select the diagonal elements of the matrix"""
+        selection = QItemSelection()
+        n = self.tablemodel.rowCount()
+        for i in range(2, n):
+            index = self.tablemodel.index(i, i)
+            selection.select(index, index)
+        self.tableview.selectionModel().select(
+            selection, QItemSelectionModel.ClearAndSelect)
+
+    def select_wrong(self):
+        """Select the off-diagonal elements of the matrix"""
+        selection = QItemSelection()
+        n = self.tablemodel.rowCount()
+        for i in range(2, n):
+            for j in range(i + 1, n):
+                index = self.tablemodel.index(i, j)
+                selection.select(index, index)
+                index = self.tablemodel.index(j, i)
+                selection.select(index, index)
+        self.tableview.selectionModel().select(
+            selection, QItemSelectionModel.ClearAndSelect)
+
+    def select_none(self):
+        """Reset selection"""
+        self.tableview.selectionModel().clear()
+
+    def cell_clicked(self, model_index):
+        """Handle cell click event"""
+        i, j = model_index.row(), model_index.column()
+        if not i or not j:
+            return
+        n = self.tablemodel.rowCount()
+        index = self.tablemodel.index
+        selection = None
+        if i == j == 1 or i == j == n - 1:
+            selection = QItemSelection(index(2, 2), index(n - 1, n - 1))
+        elif i in (1, n - 1):
+            selection = QItemSelection(index(2, j), index(n - 1, j))
+        elif j in (1, n - 1):
+            selection = QItemSelection(index(i, 2), index(i, n - 1))
+
+        if selection is not None:
+            self.tableview.selectionModel().select(
+                selection, QItemSelectionModel.ClearAndSelect)
+
+    def _prepare_data(self):
+        indices = self.tableview.selectedIndexes()
+        indices = {(ind.row() - 2, ind.column() - 2) for ind in indices}
+        actual = self.results.actual
+        learner_name = self.learners[self.selected_learner[0]]
+        predicted = self.results.predicted[self.selected_learner[0]]
+        selected = [i for i, t in enumerate(zip(actual, predicted))
+                    if t in indices]
+
+        extra = []
+        class_var = self.data.domain.class_var
+        metas = self.data.domain.metas
+
+        if self.append_predictions:
+            extra.append(predicted.reshape(-1, 1))
+            var = Orange.data.DiscreteVariable(
+                "{}({})".format(class_var.name, learner_name),
+                class_var.values
+            )
+            metas = metas + (var,)
+
+        if self.append_probabilities and \
+                        self.results.probabilities is not None:
+            probs = self.results.probabilities[self.selected_learner[0]]
+            extra.append(np.array(probs, dtype=object))
+            pvars = [Orange.data.ContinuousVariable("p({})".format(value))
+                     for value in class_var.values]
+            metas = metas + tuple(pvars)
+
+        domain = Orange.data.Domain(self.data.domain.attributes,
+                                    self.data.domain.class_vars,
+                                    metas)
+        data = self.data.transform(domain)
+        if len(extra):
+            data.metas[:, len(self.data.domain.metas):] = \
+                np.hstack(tuple(extra))
+        data.name = learner_name
+
+        if selected:
+            annotated_data = create_annotated_table(data, selected)
+            data = data[selected]
+        else:
+            annotated_data = create_annotated_table(data, [])
+            data = None
+
+        return data, annotated_data
+
+    def commit(self):
+        """Output data instances corresponding to selected cells"""
+        if self.results is not None and self.data is not None \
+                and self.selected_learner:
+            data, annotated_data = self._prepare_data()
+        else:
+            data = None
+            annotated_data = None
+
+        self.Outputs.selected_data.send(data)
+        self.Outputs.annotated_data.send(annotated_data)
+
+    def _invalidate(self):
+        indices = self.tableview.selectedIndexes()
+        self.selection = {(ind.row() - 2, ind.column() - 2) for ind in indices}
+        self.commit()
+
+    def _set_selection(self):
+        selection = QItemSelection()
+        index = self.tableview.model().index
+        for row, col in self.selection:
+            sel = index(row + 2, col + 2)
+            selection.select(sel, sel)
+        self.tableview.selectionModel().select(
+            selection, QItemSelectionModel.ClearAndSelect)
+
+    def _learner_changed(self):
+        self._update()
+        self._set_selection()
+        self.commit()
+
+    def _update(self):
+        def _isinvalid(x):
+            return isnan(x) or isinf(x)
+
+        # Update the displayed confusion matrix
+        if self.results is not None and self.selected_learner:
+            cmatrix = confusion_matrix(self.results, self.selected_learner[0])
+            colsum = cmatrix.sum(axis=0)
+            rowsum = cmatrix.sum(axis=1)
+            n = len(cmatrix)
+            diag = np.diag_indices(n)
+
+            colors = cmatrix.astype(np.double)
+            colors[diag] = 0
+            if self.selected_quantity == 0:
+                normalized = cmatrix.astype(np.int)
+                formatstr = "{}"
+                div = np.array([colors.max()])
+            else:
+                if self.selected_quantity == 1:
+                    normalized = 100 * cmatrix / colsum
+                    div = colors.max(axis=0)
+                else:
+                    normalized = 100 * cmatrix / rowsum[:, np.newaxis]
+                    div = colors.max(axis=1)[:, np.newaxis]
+                formatstr = "{:2.1f} %"
+            div[div == 0] = 1
+            colors /= div
+            colors[diag] = normalized[diag] / normalized[diag].max()
+
+            for i in range(n):
+                for j in range(n):
+                    val = normalized[i, j]
+                    col_val = colors[i, j]
+                    item = self._item(i + 2, j + 2)
+                    item.setData(
+                        "NA" if _isinvalid(val) else formatstr.format(val),
+                        Qt.DisplayRole)
+                    bkcolor = QColor.fromHsl(
+                        [0, 240][i == j], 160,
+                        255 if _isinvalid(col_val) else int(255 - 30 * col_val))
+                    item.setData(QBrush(bkcolor), Qt.BackgroundRole)
+                    item.setData("trbl", BorderRole)
+                    item.setToolTip("actual: {}\npredicted: {}".format(
+                        self.headers[i], self.headers[j]))
+                    item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+                    item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+                    self._set_item(i + 2, j + 2, item)
+
+            bold_font = self.tablemodel.invisibleRootItem().font()
+            bold_font.setBold(True)
+
+            def _sum_item(value, border=""):
+                item = QStandardItem()
+                item.setData(value, Qt.DisplayRole)
+                item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+                item.setFlags(Qt.ItemIsEnabled)
+                item.setFont(bold_font)
+                item.setData(border, BorderRole)
+                item.setData(QColor(192, 192, 192), BorderColorRole)
+                return item
+
+            for i in range(n):
+                self._set_item(n + 2, i + 2, _sum_item(int(colsum[i]), "t"))
+                self._set_item(i + 2, n + 2, _sum_item(int(rowsum[i]), "l"))
+            self._set_item(n + 2, n + 2, _sum_item(int(rowsum.sum())))
+
+    def send_report(self):
+        """Send report"""
+        if self.results is not None and self.selected_learner:
+            self.report_table(
+                "Confusion matrix for {} (showing {})".
+                format(self.learners[self.selected_learner[0]],
+                       self.quantities[self.selected_quantity].lower()),
+                self.tableview)
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        if not version:
+            # For some period of time the 'selected_learner' property was
+            # changed from List[int] -> int
+            # (commit 4e49bb3fd0e11262f3ebf4b1116a91a4b49cc982) and then back
+            # again (commit 8a492d79a2e17154a0881e24a05843406c8892c0)
+            if "selected_learner" in settings and \
+                    isinstance(settings["selected_learner"], int):
+                settings["selected_learner"] = [settings["selected_learner"]]
+
+
+if __name__ == "__main__":
+    from AnyQt.QtWidgets import QApplication
+
+    APP = QApplication([])
+    w = OWConfusionMatrix()
+    w.show()
+    IRIS = Orange.data.Table("iris")
+    RES_CV = Orange.evaluation.CrossValidation(
+        IRIS, [Orange.classification.TreeLearner(),
+               Orange.classification.MajorityLearner()],
+        store_data=True)
+    w.set_results(RES_CV)
+    APP.exec_()

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -318,7 +318,10 @@ class OWConfusionMatrix(widget.OWWidget):
             colors /= div
             colors[diag] = normalized[diag] / normalized[diag].max()
 
-            self.tableview.update_table(normalized, colsum, rowsum, colors, formatstr)
+            tooltip = lambda classv, classh:"actual: {}\npredicted: {}".format(classv, classh)
+
+            self.tableview.update_table(normalized, colsum=colsum, rowsum=rowsum, colors=colors, formatstr=formatstr,
+                                        tooltip=tooltip)
 
     def send_report(self):
         """Send report"""

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -192,7 +192,7 @@ class OWConfusionMatrix(widget.OWWidget):
         """Reset the widget, clear controls"""
         self.results = None
         self.data = None
-        self.tablemodel.clear()
+        self.tableview.clear()
         # Clear learners last. This action will invoke `_learner_changed`
         self.learners = []
 

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -106,7 +106,7 @@ class OWConfusionMatrix(widget.OWWidget):
                      orientation=Qt.Horizontal, callback=self._update)
 
         self.tablemodel = QStandardItemModel(self)
-        view = self.tableview = ContingencyTable(self, self.tablemodel, self.cell_clicked)
+        view = self.tableview = ContingencyTable(self, self.tablemodel)
         box.layout().addWidget(view)
 
         selbox = gui.hBox(box)
@@ -222,25 +222,6 @@ class OWConfusionMatrix(widget.OWWidget):
     def select_none(self):
         """Reset selection"""
         self.tableview.selectionModel().clear()
-
-    def cell_clicked(self, model_index):
-        """Handle cell click event"""
-        i, j = model_index.row(), model_index.column()
-        if not i or not j:
-            return
-        n = self.tablemodel.rowCount()
-        index = self.tablemodel.index
-        selection = None
-        if i == j == 1 or i == j == n - 1:
-            selection = QItemSelection(index(2, 2), index(n - 1, n - 1))
-        elif i in (1, n - 1):
-            selection = QItemSelection(index(2, j), index(n - 1, j))
-        elif j in (1, n - 1):
-            selection = QItemSelection(index(i, 2), index(i, n - 1))
-
-        if selection is not None:
-            self.tableview.selectionModel().select(
-                selection, QItemSelectionModel.ClearAndSelect)
 
     def _prepare_data(self):
         indices = self.tableview.selectedIndexes()

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -4,12 +4,12 @@ import Orange
 import Orange.evaluation
 import numpy as np
 import sklearn.metrics as skl_metrics
-from AnyQt.QtCore import Qt, QSize, QItemSelectionModel, QItemSelection
-from AnyQt.QtGui import QStandardItemModel
+from AnyQt.QtCore import Qt, QSize
 from Orange.widgets import widget, settings, gui
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
 from Orange.widgets.widget import Msg, Input, Output
+
 from orangecontrib.prototypes.widgets.contingency_table import ContingencyTable
 
 
@@ -105,9 +105,8 @@ class OWConfusionMatrix(widget.OWWidget):
                      items=self.quantities, label="Show: ",
                      orientation=Qt.Horizontal, callback=self._update)
 
-        self.tablemodel = QStandardItemModel(self)
-        view = self.tableview = ContingencyTable(self, self.tablemodel)
-        box.layout().addWidget(view)
+        self.tableview = ContingencyTable(self)
+        box.layout().addWidget(self.tableview)
 
         selbox = gui.hBox(box)
         gui.button(selbox, self, "Select Correct",
@@ -198,26 +197,13 @@ class OWConfusionMatrix(widget.OWWidget):
 
     def select_correct(self):
         """Select the diagonal elements of the matrix"""
-        selection = QItemSelection()
-        n = self.tablemodel.rowCount()
-        for i in range(2, n):
-            index = self.tablemodel.index(i, i)
-            selection.select(index, index)
-        self.tableview.selectionModel().select(
-            selection, QItemSelectionModel.ClearAndSelect)
+        self.tableview.set_selection({(i, i) for i in range(len(self.tableview.classesv))})
 
     def select_wrong(self):
         """Select the off-diagonal elements of the matrix"""
-        selection = QItemSelection()
-        n = self.tablemodel.rowCount()
-        for i in range(2, n):
-            for j in range(i + 1, n):
-                index = self.tablemodel.index(i, j)
-                selection.select(index, index)
-                index = self.tablemodel.index(j, i)
-                selection.select(index, index)
-        self.tableview.selectionModel().select(
-            selection, QItemSelectionModel.ClearAndSelect)
+        self.tableview.set_selection({(i, j)
+                                      for i in range(len(self.tableview.classesv))
+                                      for j in range(len(self.tableview.classesv)) if i != j})
 
     def select_none(self):
         """Reset selection"""

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -1,7 +1,5 @@
 """Confusion matrix widget"""
 
-import unicodedata
-
 import Orange
 import Orange.evaluation
 import numpy as np
@@ -172,8 +170,9 @@ class OWConfusionMatrix(widget.OWWidget):
             self.report_button.setDisabled(False)
 
             nmodels = results.predicted.shape[0]
-            self.headers = class_values + \
-                           [unicodedata.lookup("N-ARY SUMMATION")]
+            # Does self.headers have a use?
+            # self.headers = class_values + \
+            #                [unicodedata.lookup("N-ARY SUMMATION")]
 
             # NOTE: The 'learner_names' is set in 'Test Learners' widget.
             if hasattr(results, "learner_names"):
@@ -182,7 +181,7 @@ class OWConfusionMatrix(widget.OWWidget):
                 self.learners = ["Learner #{}".format(i + 1)
                                  for i in range(nmodels)]
 
-            self.tableview.initialize(self.headers)
+            self.tableview.initialize(class_values)
             self.openContext(data.domain.class_var)
             if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
                 if self.learners:

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -78,7 +78,6 @@ class OWConfusionMatrix(widget.OWWidget):
         self.data = None
         self.results = None
         self.learners = []
-        self.headers = []
 
         self.learners_box = gui.listBox(
             self.controlArea, self, "selected_learner", "learners", box=True,
@@ -170,9 +169,6 @@ class OWConfusionMatrix(widget.OWWidget):
             self.report_button.setDisabled(False)
 
             nmodels = results.predicted.shape[0]
-            # Does self.headers have a use?
-            # self.headers = class_values + \
-            #                [unicodedata.lookup("N-ARY SUMMATION")]
 
             # NOTE: The 'learner_names' is set in 'Test Learners' widget.
             if hasattr(results, "learner_names"):
@@ -197,7 +193,6 @@ class OWConfusionMatrix(widget.OWWidget):
         self.results = None
         self.data = None
         self.tablemodel.clear()
-        self.headers = []
         # Clear learners last. This action will invoke `_learner_changed`
         self.learners = []
 

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -185,7 +185,7 @@ class OWConfusionMatrix(widget.OWWidget):
             else:
                 self.selected_learner[:] = prev_sel_learner
             self._update()
-            self._set_selection()
+            self.tableview.set_selection(self.selection)
             self.unconditional_commit()
 
     def clear(self):
@@ -287,18 +287,8 @@ class OWConfusionMatrix(widget.OWWidget):
         self.selection = {(ind.row() - 2, ind.column() - 2) for ind in indices}
         self.commit()
 
-    def _set_selection(self):
-        selection = QItemSelection()
-        index = self.tableview.model().index
-        for row, col in self.selection:
-            sel = index(row + 2, col + 2)
-            selection.select(sel, sel)
-        self.tableview.selectionModel().select(
-            selection, QItemSelectionModel.ClearAndSelect)
-
     def _learner_changed(self):
         self._update()
-        self._set_selection()
         self.commit()
 
     def _update(self):

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -304,7 +304,9 @@ class OWConfusionMatrix(widget.OWWidget):
             colors /= div
             colors[diag] = normalized[diag] / normalized[diag].max()
 
-            tooltip = lambda classv, classh:"actual: {}\npredicted: {}".format(classv, classh)
+            def tooltip(i, j):
+                return "actual: {}\npredicted: {}".format(self.tableview.classesv[i],
+                                                          self.tableview.classesh[j])
             self.tableview.update_table(normalized, colsum=colsum, rowsum=rowsum, colors=colors, formatstr=formatstr,
                                         tooltip=tooltip)
 

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -177,8 +177,7 @@ class OWConfusionMatrix(widget.OWWidget):
                 self.learners = ["Learner #{}".format(i + 1)
                                  for i in range(nmodels)]
 
-            self.tableview.initialize(classesv=class_values, classesh=class_values,
-                                      headerv="Actual", headerh="Predicted")
+            self.tableview.set_headers(class_values, class_values, "Actual", "Predicted")
             self.openContext(data.domain.class_var)
             if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
                 if self.learners:

--- a/orangecontrib/prototypes/widgets/owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/owconfusionmatrix.py
@@ -177,7 +177,8 @@ class OWConfusionMatrix(widget.OWWidget):
                 self.learners = ["Learner #{}".format(i + 1)
                                  for i in range(nmodels)]
 
-            self.tableview.initialize(class_values)
+            self.tableview.initialize(classesv=class_values, classesh=class_values,
+                                      headerv="Actual", headerh="Predicted")
             self.openContext(data.domain.class_var)
             if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
                 if self.learners:
@@ -319,7 +320,6 @@ class OWConfusionMatrix(widget.OWWidget):
             colors[diag] = normalized[diag] / normalized[diag].max()
 
             tooltip = lambda classv, classh:"actual: {}\npredicted: {}".format(classv, classh)
-
             self.tableview.update_table(normalized, colsum=colsum, rowsum=rowsum, colors=colors, formatstr=formatstr,
                                         tooltip=tooltip)
 

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -154,7 +154,7 @@ def contingency_table(data, columns, rows):
     return Table(domain, ct, metas=metas)
 
 
-def test():
+def main():
     from AnyQt.QtWidgets import QApplication
     app = QApplication([])
 
@@ -167,4 +167,4 @@ def test():
 
 
 if __name__ == "__main__":
-    test()
+    main()

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -1,5 +1,6 @@
 from AnyQt.QtGui import QStandardItemModel
 from AnyQt.QtWidgets import QLabel
+import numpy as np
 from Orange.data import (ContinuousVariable, DiscreteVariable, StringVariable,
                          Domain, Table)
 from Orange.data.filter import FilterDiscrete, Values
@@ -85,10 +86,6 @@ class OWContingencyTable(widget.OWWidget):
     def handleNewSignals(self):
         self._attribute_changed()
 
-    def _find_matching_ids(self, orig, filtered):
-        filtered_ids = set(filtered.ids)
-        return [ix for ix, id in enumerate(orig.ids) if id in filtered_ids]
-
     def commit(self):
         if len(self.selection):
             cells = []
@@ -97,7 +94,8 @@ class OWContingencyTable(widget.OWWidget):
                     if (ir, ic) in self.selection:
                         cells.append(Values([FilterDiscrete(self.rows, [r]), FilterDiscrete(self.columns, [c])]))
             selected_data = Values(cells, conjunction=False)(self.data)
-            annotated_data = create_annotated_table(self.data, self._find_matching_ids(self.data, selected_data))
+            annotated_data = create_annotated_table(self.data,
+                                                    np.where(np.in1d(self.data.ids, selected_data.ids, True)))
         else:
             selected_data = None
             annotated_data = create_annotated_table(self.data, [])

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -6,6 +6,7 @@ from Orange.statistics import contingency
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import (Setting, ContextSetting,
                                      DomainContextHandler)
+from Orange.widgets.utils.annotated_data import create_annotated_table, ANNOTATED_DATA_SIGNAL_NAME
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.sql import check_sql_input
 
@@ -20,7 +21,8 @@ class OWContingencyTable(widget.OWWidget):
 
     inputs = [("Data", Table, "set_data", widget.Default)]
     outputs = [("Contingency Table", Table, ),
-               ("Selected Data", Table, )]
+               ("Selected Data", Table),
+               (ANNOTATED_DATA_SIGNAL_NAME, Table)]
 
     settingsHandler = DomainContextHandler(metas_in_res=True)
     rows = ContextSetting(None)
@@ -83,10 +85,13 @@ class OWContingencyTable(widget.OWWidget):
                     if (ir, ic) in self.selection:
                         cells.append(Values([FilterDiscrete(self.rows, [r]), FilterDiscrete(self.columns, [c])]))
             selected_data = Values(cells, conjunction=False)(self.data)
+            annotated_data = create_annotated_table(self.data, selected_data.ids)
         else:
             selected_data = None
-        self.send("Selected Data", selected_data)
+            annotated_data = create_annotated_table(self.data, [])
         self.send("Contingency Table", self.table)
+        self.send("Selected Data", selected_data)
+        self.send(ANNOTATED_DATA_SIGNAL_NAME, annotated_data)
 
     def _invalidate(self):
         self.selection = self.tableview.get_selection()

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -1,6 +1,5 @@
-from AnyQt.QtGui import QStandardItemModel
-from AnyQt.QtWidgets import QLabel
 import numpy as np
+from AnyQt.QtGui import QStandardItemModel
 from Orange.data import (ContinuousVariable, DiscreteVariable, StringVariable,
                          Domain, Table)
 from Orange.data.filter import FilterDiscrete, Values
@@ -51,10 +50,10 @@ class OWContingencyTable(widget.OWWidget):
         gui.comboBox(box, self, 'columns', sendSelectedValue=True,
                      model=self.feature_model, callback=self._attribute_changed)
 
-        self.controlArea.layout().addStretch()
+        gui.rubber(self.controlArea)
 
-        self.scores = QLabel(self)
-        self.controlArea.layout().addWidget(self.scores)
+        box = gui.vBox(self.controlArea, "Scores")
+        self.scores = gui.widgetLabel(box, "\n\n")
 
         self.apply_button = gui.auto_commit(
             self.controlArea, self, "auto_apply", "&Apply", box=False)
@@ -124,7 +123,7 @@ class OWContingencyTable(widget.OWWidget):
                 chi.chisq,
                 chi.p))
         else:
-            self.scores.setText("")
+            self.scores.setText("\n\n")
         self._invalidate()
 
     def send_report(self):

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -85,7 +85,7 @@ class OWContingencyTable(widget.OWWidget):
                 self.table = contingency_table(self.data, self.columns, self.rows)
                 self.tableview.update_table(self.table.X, formatstr="{:.0f}")
         else:
-            self.tablemodel.clear()
+            self.tableview.clear()
 
     def handleNewSignals(self):
         self._attribute_changed()

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -76,7 +76,7 @@ class OWContingencyTable(widget.OWWidget):
                 self.rows = self.feature_model[0]
                 self.columns = self.feature_model[0]
                 self.openContext(data)
-                self.tableview.initialize(self.rows.values, self.columns.values)
+                self.tableview.initialize(variablev=self.rows, variableh=self.columns)
                 self.table = contingency_table(self.data, self.columns, self.rows)
                 self.tableview.update_table(self.table.X, formatstr="{:.0f}")
         else:
@@ -110,7 +110,7 @@ class OWContingencyTable(widget.OWWidget):
         self.tableview.set_selection(self.selection)
         self.table = None
         if self.data and self.rows and self.columns:
-            self.tableview.initialize(self.rows.values, self.columns.values)
+            self.tableview.initialize(variablev=self.rows, variableh=self.columns)
             self.table = contingency_table(self.data, self.columns, self.rows)
             self.tableview.update_table(self.table.X, formatstr="{:.0f}")
 

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -46,7 +46,7 @@ class OWContingencyTable(widget.OWWidget):
             self.controlArea, self, "auto_apply", "&Apply", box=False)
 
         self.tablemodel = QStandardItemModel(self)
-        view = self.tableview = ContingencyTable(self, self.tablemodel, None)
+        view = self.tableview = ContingencyTable(self, self.tablemodel)
         self.mainArea.layout().addWidget(view)
 
     @check_sql_input

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -33,6 +33,7 @@ class OWContingencyTable(widget.OWWidget):
 
         self.data = None
         self.feature_model = DomainModel(valid_types=DiscreteVariable)
+        self.table = None
 
         box = gui.vBox(self.controlArea, "Rows")
         gui.comboBox(box, self, 'rows', sendSelectedValue=True,
@@ -66,23 +67,25 @@ class OWContingencyTable(widget.OWWidget):
                 self.tableview.initialize(
                     self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
                     self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
-                table = contingency_table(self.data, self.columns, self.rows)
-                self.tableview.update_table(table.X, formatstr="{:.0f}")
+                self.table = contingency_table(self.data, self.columns, self.rows)
+                self.tableview.update_table(self.table.X, formatstr="{:.0f}")
+        else:
+            self.tablemodel.clear()
 
     def handleNewSignals(self):
         self._invalidate()
 
     def commit(self):
-        table = None
-        if self.data and self.rows and self.columns:
-            table = contingency_table(self.data, self.columns, self.rows)
-            self.tableview.update_table(table.X, formatstr="{:.0f}")
-        self.send("Contingency Table", table)
+        self.send("Contingency Table", self.table)
 
     def _invalidate(self):
-        self.tableview.initialize(
-            self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
-            self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
+        self.table = None
+        if self.data and self.rows and self.columns:
+            self.tableview.initialize(
+                self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
+                self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
+            self.table = contingency_table(self.data, self.columns, self.rows)
+            self.tableview.update_table(self.table.X, formatstr="{:.0f}")
         self.commit()
 
     def send_report(self):

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -66,6 +66,8 @@ class OWContingencyTable(widget.OWWidget):
                 self.tableview.initialize(
                     self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
                     self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
+                table = contingency_table(self.data, self.columns, self.rows)
+                self.tableview.update_table(table.X, formatstr="{:.0f}")
 
     def handleNewSignals(self):
         self._invalidate()
@@ -74,12 +76,13 @@ class OWContingencyTable(widget.OWWidget):
         table = None
         if self.data and self.rows and self.columns:
             table = contingency_table(self.data, self.columns, self.rows)
-            self.tableview.initialize(
-                self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
-                self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
+            self.tableview.update_table(table.X, formatstr="{:.0f}")
         self.send("Contingency Table", table)
 
     def _invalidate(self):
+        self.tableview.initialize(
+            self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
+            self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
         self.commit()
 
     def send_report(self):

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -1,5 +1,4 @@
 import numpy as np
-from AnyQt.QtGui import QStandardItemModel
 from Orange.data import (ContinuousVariable, DiscreteVariable, StringVariable,
                          Domain, Table)
 from Orange.data.filter import FilterDiscrete, Values
@@ -62,9 +61,8 @@ class OWContingencyTable(widget.OWWidget):
         self.apply_button = gui.auto_commit(
             self.controlArea, self, "auto_apply", "&Apply", box=False)
 
-        self.tablemodel = QStandardItemModel(self)
-        view = self.tableview = ContingencyTable(self, self.tablemodel)
-        self.mainArea.layout().addWidget(view)
+        self.tableview = ContingencyTable(self)
+        self.mainArea.layout().addWidget(self.tableview)
 
     @Inputs.data
     @check_sql_input

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -76,7 +76,7 @@ class OWContingencyTable(widget.OWWidget):
                 self.rows = self.feature_model[0]
                 self.columns = self.feature_model[0]
                 self.openContext(data)
-                self.tableview.initialize(variablev=self.rows, variableh=self.columns)
+                self.tableview.set_variables(self.rows, self.columns)
                 self.table = contingency_table(self.data, self.columns, self.rows)
                 self.tableview.update_table(self.table.X, formatstr="{:.0f}")
         else:
@@ -110,7 +110,7 @@ class OWContingencyTable(widget.OWWidget):
         self.tableview.set_selection(self.selection)
         self.table = None
         if self.data and self.rows and self.columns:
-            self.tableview.initialize(variablev=self.rows, variableh=self.columns)
+            self.tableview.set_variables(self.rows, self.columns)
             self.table = contingency_table(self.data, self.columns, self.rows)
             self.tableview.update_table(self.table.X, formatstr="{:.0f}")
 

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -85,6 +85,10 @@ class OWContingencyTable(widget.OWWidget):
     def handleNewSignals(self):
         self._attribute_changed()
 
+    def _find_matching_ids(self, orig, filtered):
+        filtered_ids = set(filtered.ids)
+        return [ix for ix, id in enumerate(orig.ids) if id in filtered_ids]
+
     def commit(self):
         if len(self.selection):
             cells = []
@@ -93,7 +97,7 @@ class OWContingencyTable(widget.OWWidget):
                     if (ir, ic) in self.selection:
                         cells.append(Values([FilterDiscrete(self.rows, [r]), FilterDiscrete(self.columns, [c])]))
             selected_data = Values(cells, conjunction=False)(self.data)
-            annotated_data = create_annotated_table(self.data, selected_data.ids)
+            annotated_data = create_annotated_table(self.data, self._find_matching_ids(self.data, selected_data))
         else:
             selected_data = None
             annotated_data = create_annotated_table(self.data, [])

--- a/orangecontrib/prototypes/widgets/owcontingency.py
+++ b/orangecontrib/prototypes/widgets/owcontingency.py
@@ -1,4 +1,3 @@
-import unicodedata
 from AnyQt.QtGui import QStandardItemModel
 from Orange.data import (ContinuousVariable, DiscreteVariable, StringVariable,
                          Domain, Table)
@@ -64,9 +63,7 @@ class OWContingencyTable(widget.OWWidget):
                 self.rows = self.feature_model[0]
                 self.columns = self.feature_model[0]
                 self.openContext(data)
-                self.tableview.initialize(
-                    self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
-                    self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
+                self.tableview.initialize(self.rows.values, self.columns.values)
                 self.table = contingency_table(self.data, self.columns, self.rows)
                 self.tableview.update_table(self.table.X, formatstr="{:.0f}")
         else:
@@ -81,9 +78,7 @@ class OWContingencyTable(widget.OWWidget):
     def _invalidate(self):
         self.table = None
         if self.data and self.rows and self.columns:
-            self.tableview.initialize(
-                self.rows.values + [unicodedata.lookup("N-ARY SUMMATION")],
-                self.columns.values + [unicodedata.lookup("N-ARY SUMMATION")])
+            self.tableview.initialize(self.rows.values, self.columns.values)
             self.table = contingency_table(self.data, self.columns, self.rows)
             self.tableview.update_table(self.table.X, formatstr="{:.0f}")
         self.commit()

--- a/orangecontrib/prototypes/widgets/tests/test_contingency_table.py
+++ b/orangecontrib/prototypes/widgets/tests/test_contingency_table.py
@@ -14,28 +14,39 @@ class TestContingencyTable(GuiTest):
         self.var1 = DiscreteVariable("char", ("a", "b"), ordered=True)
         self.var2 = DiscreteVariable("num", ("0", "1"), ordered=True)
 
-    def _get(self, i, j):
-        return self.table._item(i, j).data(Qt.DisplayRole)
-
-    def _get_headers(self):
-        return ([self._get(i, 1) for i in range(2, self.table.tablemodel.rowCount() - 1)]
-                + [self._get(1, j) for j in range(2, self.table.tablemodel.columnCount() - 1)]
-                + [self._get(2, 0), self._get(0, 2)])
-
     def test_set_variables(self):
         self.table.set_variables(self.var1, self.var2)
         self.assertEqual(self.var1.values + self.var2.values + [self.var1.name, self.var2.name], self._get_headers())
-
-    def _get_data(self):
-        return [self._get(i, j)
-                for i in range(2, self.table.tablemodel.rowCount() - 1)
-                for j in range(2, self.table.tablemodel.columnCount() - 1)]
 
     def test_update_table(self):
         self.table.set_variables(self.var1, self.var2)
         array = np.array([[1, 2], [3, 4]])
         self.table.update_table(array)
         self.assertEqual([str(x) for x in array.flatten()], self._get_data())
+
+    def _get(self, i, j):
+        return self.table._item(i, j).data(Qt.DisplayRole)
+
+    def _get_row_label(self):
+        return self._get(2, 0)
+
+    def _get_row_headers(self):
+        return [self._get(i, 1) for i in range(2, self.table.tablemodel.rowCount() - 1)]
+
+    def _get_column_label(self):
+        return self._get(0, 2)
+
+    def _get_column_headers(self):
+        return [self._get(1, j) for j in range(2, self.table.tablemodel.columnCount() - 1)]
+
+    def _get_headers(self):
+        return (self._get_row_headers() + self._get_column_headers()
+                + [self._get_row_label(), self._get_column_label()])
+
+    def _get_data(self):
+        return [self._get(i, j)
+                for i in range(2, self.table.tablemodel.rowCount() - 1)
+                for j in range(2, self.table.tablemodel.columnCount() - 1)]
 
 
 if __name__ == "__main__":

--- a/orangecontrib/prototypes/widgets/tests/test_contingency_table.py
+++ b/orangecontrib/prototypes/widgets/tests/test_contingency_table.py
@@ -1,0 +1,42 @@
+import numpy as np
+from Orange.data import DiscreteVariable
+from Orange.widgets.tests.base import GuiTest
+from Orange.widgets.widget import OWWidget
+from AnyQt.QtCore import Qt
+import unittest
+
+from orangecontrib.prototypes.widgets.contingency_table import ContingencyTable
+
+
+class TestContingencyTable(GuiTest):
+    def setUp(self):
+        self.table = ContingencyTable(OWWidget())
+        self.var1 = DiscreteVariable("char", ("a", "b"), ordered=True)
+        self.var2 = DiscreteVariable("num", ("0", "1"), ordered=True)
+
+    def _get(self, i, j):
+        return self.table._item(i, j).data(Qt.DisplayRole)
+
+    def _get_headers(self):
+        return ([self._get(i, 1) for i in range(2, self.table.tablemodel.rowCount() - 1)]
+                + [self._get(1, j) for j in range(2, self.table.tablemodel.columnCount() - 1)]
+                + [self._get(2, 0), self._get(0, 2)])
+
+    def test_set_variables(self):
+        self.table.set_variables(self.var1, self.var2)
+        self.assertEqual(self.var1.values + self.var2.values + [self.var1.name, self.var2.name], self._get_headers())
+
+    def _get_data(self):
+        return [self._get(i, j)
+                for i in range(2, self.table.tablemodel.rowCount() - 1)
+                for j in range(2, self.table.tablemodel.columnCount() - 1)]
+
+    def test_update_table(self):
+        self.table.set_variables(self.var1, self.var2)
+        array = np.array([[1, 2], [3, 4]])
+        self.table.update_table(array)
+        self.assertEqual([str(x) for x in array.flatten()], self._get_data())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/prototypes/widgets/tests/test_contingency_table.py
+++ b/orangecontrib/prototypes/widgets/tests/test_contingency_table.py
@@ -16,7 +16,10 @@ class TestContingencyTable(GuiTest):
 
     def test_set_variables(self):
         self.table.set_variables(self.var1, self.var2)
-        self.assertEqual(self.var1.values + self.var2.values + [self.var1.name, self.var2.name], self._get_headers())
+        self.assertEqual(self.var1.name, self._get_row_label())
+        self.assertEqual(self.var2.name, self._get_column_label())
+        self.assertEqual(self.var1.values, self._get_row_headers())
+        self.assertEqual(self.var2.values, self._get_column_headers())
 
     def test_update_table(self):
         self.table.set_variables(self.var1, self.var2)
@@ -38,10 +41,6 @@ class TestContingencyTable(GuiTest):
 
     def _get_column_headers(self):
         return [self._get(1, j) for j in range(2, self.table.tablemodel.columnCount() - 1)]
-
-    def _get_headers(self):
-        return (self._get_row_headers() + self._get_column_headers()
-                + [self._get_row_label(), self._get_column_label()])
 
     def _get_data(self):
         return [self._get(i, j)

--- a/orangecontrib/prototypes/widgets/tests/test_owconfusionmatrix.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owconfusionmatrix.py
@@ -1,0 +1,117 @@
+# pylint: disable=missing-docstring
+import numpy as np
+
+from Orange.data import Table
+from Orange.classification import NaiveBayesLearner, TreeLearner
+from Orange.regression import MeanLearner
+from Orange.evaluation.testing import CrossValidation, TestOnTrainingData, \
+    ShuffleSplit, Results
+from Orange.widgets.evaluate.owconfusionmatrix import OWConfusionMatrix
+from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+
+
+class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        WidgetOutputsTestMixin.init(cls)
+
+        bayes = NaiveBayesLearner()
+        tree = TreeLearner()
+        cls.iris = cls.data
+        titanic = Table("titanic")
+        common = dict(k=3, store_data=True)
+        cls.results_1_iris = CrossValidation(cls.iris, [bayes], **common)
+        cls.results_2_iris = CrossValidation(cls.iris, [bayes, tree], **common)
+        cls.results_2_titanic = CrossValidation(titanic, [bayes, tree],
+                                                **common)
+
+        cls.signal_name = "Evaluation Results"
+        cls.signal_data = cls.results_1_iris
+        cls.same_input_output_domain = False
+
+    def setUp(self):
+        self.widget = self.create_widget(OWConfusionMatrix,
+                                         stored_settings={"auto_apply": False})
+
+    def test_selected_learner(self):
+        """Check learner and model for various values of all parameters
+        when pruning parameters are not checked
+        """
+        self.send_signal(self.widget.Inputs.evaluation_results, self.results_2_iris)
+        self.assertEqual(self.widget.selected_learner, [0])
+        self.widget.selected_learner[:] = [1]
+        self.send_signal(self.widget.Inputs.evaluation_results, self.results_2_titanic)
+        self.widget.selected_learner[:] = [1]
+        self.send_signal(self.widget.Inputs.evaluation_results, self.results_1_iris)
+        self.widget.selected_learner[:] = [0]
+        self.send_signal(self.widget.Inputs.evaluation_results, None)
+        self.send_signal(self.widget.Inputs.evaluation_results, self.results_1_iris)
+        self.widget.selected_learner[:] = [0]
+
+    def _select_data(self):
+        self.widget.select_correct()
+        indices = self.widget.tableview.selectedIndexes()
+        indices = {(ind.row() - 2, ind.column() - 2) for ind in indices}
+        selected = [i for i, t in enumerate(zip(
+            self.widget.results.actual, self.widget.results.predicted[0]))
+                    if t in indices]
+        return self.widget.results.row_indices[selected]
+
+    def test_show_error_on_regression(self):
+        """On regression data, the widget must show error"""
+        housing = Table("housing")
+        results = TestOnTrainingData(housing, [MeanLearner()], store_data=True)
+        self.send_signal(self.widget.Inputs.evaluation_results, results)
+        self.assertTrue(self.widget.Error.no_regression.is_shown())
+        self.send_signal(self.widget.Inputs.evaluation_results, None)
+        self.assertFalse(self.widget.Error.no_regression.is_shown())
+        self.send_signal(self.widget.Inputs.evaluation_results, results)
+        self.assertTrue(self.widget.Error.no_regression.is_shown())
+        self.send_signal(self.widget.Inputs.evaluation_results, self.results_1_iris)
+        self.assertFalse(self.widget.Error.no_regression.is_shown())
+
+    def test_row_indices(self):
+        """Map data instances when using random shuffling"""
+        results = ShuffleSplit(self.iris, [NaiveBayesLearner()],
+                               store_data=True)
+        self.send_signal(self.widget.Inputs.evaluation_results, results)
+        self.widget.select_correct()
+        selected = self.get_output(self.widget.Outputs.selected_data)
+        correct = np.equal(results.actual, results.predicted)[0]
+        correct_indices = results.row_indices[correct]
+        self.assertSetEqual(set(self.iris[correct_indices].ids),
+                            set(selected.ids))
+
+    def test_empty_results(self):
+        """Test on empty results."""
+        res = Results(data=self.iris[:0], store_data=True)
+        res.row_indices = np.array([], dtype=int)
+        res.actual = np.array([])
+        res.predicted = np.array([[]])
+        res.probabilities = np.zeros((1, 0, 3))
+        self.send_signal(self.widget.Inputs.evaluation_results, res)
+        self.widget.select_correct()
+        self.widget.select_wrong()
+
+    def test_nan_results(self):
+        """Test on results with nan values in actual/predicted"""
+        res = Results(data=self.iris, nmethods=2, store_data=True)
+        res.row_indices = np.array([0, 50, 100], dtype=int)
+        res.actual = np.array([0., np.nan, 2.])
+        res.predicted = np.array([[np.nan, 1, 2],
+                                  [np.nan, np.nan, np.nan]])
+        res.probabilities = np.zeros((1, 3, 3))
+        self.send_signal(self.widget.Inputs.evaluation_results, res)
+        self.assertTrue(self.widget.Error.invalid_values.is_shown())
+        self.send_signal(self.widget.Inputs.evaluation_results, None)
+        self.assertFalse(self.widget.Error.invalid_values.is_shown())
+
+    def test_not_append_extra_meta_columns(self):
+        """
+        When a user does not want append extra meta column, the widget
+        should not crash.
+        GH-2386
+        """
+        self.widget.append_predictions = False
+        self.send_signal(self.widget.Inputs.evaluation_results, self.results_1_iris)

--- a/orangecontrib/prototypes/widgets/tests/test_owcontingency.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcontingency.py
@@ -1,0 +1,69 @@
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+
+from orangecontrib.prototypes.widgets.owcontingency import OWContingencyTable
+
+
+class TestOWContingencyTable(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWContingencyTable)
+        self.titanic = Table("titanic")
+
+    def test_input(self):
+        """
+        Test whether correct outputs appear when input is provided.
+        """
+        self.send_signal(self.widget.Inputs.data, self.titanic)
+        self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
+        self.assertIsNotNone(self.get_output(self.widget.Outputs.annotated_data))
+        self.assertIsNotNone(self.get_output(self.widget.Outputs.contingency))
+
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
+        self.assertIsNone(self.get_output(self.widget.Outputs.annotated_data))
+        self.assertIsNone(self.get_output(self.widget.Outputs.contingency))
+
+    def test_attribute_selection(self):
+        """
+        Test selection of row an column attributes.
+        """
+        self.send_signal(self.widget.Inputs.data, self.titanic)
+
+        self.widget.rows = self.titanic.domain["survived"]
+        self.widget.columns = self.titanic.domain["survived"]
+        self.widget._attribute_changed()
+        self.assertEqual((2, 2), self.get_output(self.widget.Outputs.contingency).X.shape)
+
+        self.widget.rows = self.titanic.domain["survived"]
+        self.widget.columns = self.titanic.domain["status"]
+        self.widget._attribute_changed()
+        self.assertEqual((2, 4), self.get_output(self.widget.Outputs.contingency).X.shape)
+
+        self.widget.rows = self.titanic.domain["status"]
+        self.widget.columns = self.titanic.domain["survived"]
+        self.widget._attribute_changed()
+        self.assertEqual((4, 2), self.get_output(self.widget.Outputs.contingency).X.shape)
+
+    def test_filtering(self):
+        """
+        Test data filtering based on selected cells in the table.
+        """
+        self.send_signal(self.widget.Inputs.data, self.titanic)
+        self.widget.rows = self.titanic.domain["survived"]
+        self.widget.columns = self.titanic.domain["status"]
+
+        self.widget.selection = {}
+        self.widget.commit()
+        self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
+
+        self.widget.selection = {(0, 0)}
+        self.widget.commit()
+        self.assertEqual(673, len(self.get_output(self.widget.Outputs.selected_data)))
+
+        self.widget.selection = {(0, 0), (1, 0)}
+        self.widget.commit()
+        self.assertEqual(673 + 212, len(self.get_output(self.widget.Outputs.selected_data)))
+
+        self.widget.selection = {(0, 0), (0, 1)}
+        self.widget.commit()
+        self.assertEqual(673 + 122, len(self.get_output(self.widget.Outputs.selected_data)))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
biolab/orange3#2966

##### Description of changes

Extracted the table in Confusion Matrix widget into a separate class and added a copy of Confusion Matrix widget which uses that class. Added this table and clustering scores to Contingency Table widget. Also added Selected Data and Data outputs which correspond to selected cells in the table (same as in Confusion Matrix).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
