### PR TITLE
Feature statistics improvements

### DIFF
--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -144,7 +144,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         _dispersion = partial(
             _apply_to_types,
             discrete_f=lambda x: _entropy(x),
-            continuous_f=lambda x: ut.nanvar(x, axis=0),
+            continuous_f=lambda x: ut.nanvar(x, axis=0) / ut.nanmean(x, axis=0),
         )
         self._dispersion = np.hstack(map(_dispersion, matrices))
 

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -410,10 +410,9 @@ class FeatureStatisticsTableView(QTableView):
             cornerButtonEnabled=False,
             sortingEnabled=True,
             selectionBehavior=QTableView.SelectRows,
-            selectionMode=QTableView.MultiSelection,
+            selectionMode=QTableView.ExtendedSelection,
             horizontalScrollMode=QTableView.ScrollPerPixel,
             verticalScrollMode=QTableView.ScrollPerPixel,
-            focusPolicy=Qt.NoFocus,
             **kwargs
         )
         self.setModel(model)
@@ -442,8 +441,10 @@ class FeatureStatisticsTableView(QTableView):
         vheader.setVisible(False)
         vheader.setSectionResizeMode(QHeaderView.Fixed)
         hheader.sectionResized.connect(self.bind_histogram_aspect_ratio)
-        hheader.sectionResized.connect(self.keep_row_centered)
+        # TODO: This shifts the scrollarea a bit down when opening widget
+        # hheader.sectionResized.connect(self.keep_row_centered)
 
+        self.setItemDelegate(NoFocusRectDelegate(parent=self))
         self.setItemDelegateForColumn(
             FeatureStatisticsTableModel.Columns.DISTRIBUTION,
             DistributionDelegate(parent=self),
@@ -474,6 +475,15 @@ class FeatureStatisticsTableView(QTableView):
         bottom_row = self.indexAt(self.rect().bottomLeft()).row()
         middle_row = top_row + (bottom_row - top_row) // 2
         self.scrollTo(self.model().index(middle_row, 0), QTableView.PositionAtCenter)
+
+
+class NoFocusRectDelegate(QStyledItemDelegate):
+    """Removes the light blue background and border on a focused item."""
+
+    def paint(self, painter, option, index):
+        # type: (QPainter, QStyleOptionViewItem, QModelIndex) -> None
+        option.state &= ~QStyle.State_HasFocus
+        super().paint(painter, option, index)
 
 
 class DistributionDelegate(QStyledItemDelegate):

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -417,10 +417,14 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                 'We do not deal with non numeric values in sorting by ' \
                 'multiple values'
             if order == Qt.DescendingOrder:
-                data[:, :-1] = -(data[:, :-1].astype(np.float64))
+                data[:, -1] = -data[:, -1]
+
+            # In order to make sure NaNs always appear at the end, insert a
+            # indicator whether NaN or not
+            nans = np.isnan(data[:, -1]).astype(int)
+            data = np.insert(data, nans, -2, axis=1)
+
             indices = np.lexsort(np.flip(data.T, axis=0))
-            if order == Qt.DescendingOrder:
-                indices = indices[::-1]
 
         return indices
 

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -507,7 +507,7 @@ class OWFeatureStatistics(widget.OWWidget):
     color_var = ContextSetting(None)  # type: Optional[Variable]
     # filter_string = ContextSetting('')
 
-    sorting = Setting((0, Qt.DescendingOrder))
+    sorting = ContextSetting((0, Qt.DescendingOrder))
     selected_rows = ContextSetting([])
 
     def __init__(self):
@@ -555,6 +555,7 @@ class OWFeatureStatistics(widget.OWWidget):
         self.model = FeatureStatisticsTableModel(parent=self)
         self.table_view = FeatureStatisticsTableView(self.model, parent=self)
         self.table_view.selectionModel().selectionChanged.connect(self.on_select)
+        self.table_view.horizontalHeader().sectionClicked.connect(self.on_header_click)
 
         self.mainArea.layout().addWidget(self.table_view)
 
@@ -591,6 +592,7 @@ class OWFeatureStatistics(widget.OWWidget):
         self.openContext(self.data)
         self.model.set_data(data)
         self.__restore_selection()
+        self.__restore_sorting()
         # self._filter_table_variables()
         self.__color_var_changed()
 
@@ -607,6 +609,20 @@ class OWFeatureStatistics(widget.OWWidget):
                     self.model.index(row, self.model.columnCount() - 1)
                 ))
         selection_model.select(selection, QItemSelectionModel.ClearAndSelect)
+
+    def __restore_sorting(self):
+        """Restore the sort column and order from saved settings."""
+        sort_column, sort_order = self.sorting
+        if sort_column < self.model.columnCount():
+            self.model.sort(sort_column, sort_order)
+            self.table_view.horizontalHeader().setSortIndicator(sort_column, sort_order)
+
+    @pyqtSlot(int)
+    def on_header_click(self, *_):
+        # Store the header states
+        sort_order = self.model.sortOrder()
+        sort_column = self.model.sortColumn()
+        self.sorting = sort_column, sort_order
 
     @pyqtSlot(int)
     def __color_var_changed(self, *_):

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -263,7 +263,6 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         elif column == self.Columns.NAME:
             return self._variable_names
         elif column == self.Columns.DISTRIBUTION:
-            # TODO Implement some form of sorting over the histograms
             return self._variable_names
         elif column == self.Columns.CENTER:
             return self._center
@@ -275,6 +274,16 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
             return self._max
         elif column == self.Columns.MISSING:
             return self._missing
+
+    def _argsortData(self, data, order):
+        """Always sort NaNs last."""
+        indices = np.argsort(data, kind='mergesort')
+        if order == Qt.DescendingOrder:
+            indices = indices[::-1]
+            if np.issubdtype(data.dtype, np.number):
+                indices = np.roll(indices, -np.isnan(data).sum())
+            return indices
+        return indices
 
     def headerData(self, section, orientation, role):
         # type: (int, Qt.Orientation, Qt.ItemDataRole) -> Any
@@ -588,9 +597,9 @@ class OWFeatureStatistics(widget.OWWidget):
         else:
             self.color_var_model.set_domain(None)
             self.color_var = None
+        self.model.set_data(data)
 
         self.openContext(self.data)
-        self.model.set_data(data)
         self.__restore_selection()
         self.__restore_sorting()
         # self._filter_table_variables()

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -239,19 +239,29 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         if not len(matrices):
             return np.array([])
 
+        def _to_float(data):
+            if not np.issubdtype(data.dtype, np.number):
+                data = data.astype(np.float64)
+            return data
+
+        def _to_object(data):
+            if data.dtype is not np.object:
+                data = data.astype(np.object)
+            return data
+
         results = []
         for variables, x in matrices:
             result = np.full(len(variables), default_val)
 
             disc_idx, cont_idx, time_idx, str_idx = self._attr_indices(variables)
             if discrete_f and x[:, disc_idx].size:
-                result[disc_idx] = discrete_f(x[:, disc_idx].astype(np.float64))
+                result[disc_idx] = discrete_f(_to_float(x[:, disc_idx]))
             if continuous_f and x[:, cont_idx].size:
-                result[cont_idx] = continuous_f(x[:, cont_idx].astype(np.float64))
+                result[cont_idx] = continuous_f(_to_float(x[:, cont_idx]))
             if time_f and x[:, time_idx].size:
-                result[time_idx] = time_f(x[:, time_idx].astype(np.float64))
+                result[time_idx] = time_f(_to_float(x[:, time_idx]))
             if string_f and x[:, str_idx].size:
-                result[str_idx] = string_f(x[:, str_idx].astype(np.object))
+                result[str_idx] = string_f(_to_object(x[:, str_idx]))
 
             results.append(result)
 

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -59,7 +59,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                     self.DISPERSION: 'Dispersion',
                     self.MIN: 'Min.',
                     self.MAX: 'Max.',
-                    self.MISSING: 'Missing values',
+                    self.MISSING: 'Missing',
                     }[self.value]
 
         @property
@@ -417,7 +417,7 @@ class OWFeatureStatistics(widget.OWWidget):
         # widget is not shown, size `sizeHint` is called on every row.
         hheader.setResizeContentsPrecision(5)
         # Set a nice default size so that headers have some space around titles
-        hheader.setDefaultSectionSize(120)
+        hheader.setDefaultSectionSize(100)
         # Set individual column behaviour in `set_data` since the logical
         # indices must be valid in the model, which requires data.
         hheader.setSectionResizeMode(QHeaderView.Interactive)
@@ -463,7 +463,7 @@ class OWFeatureStatistics(widget.OWWidget):
         self.mainArea.layout().addWidget(self.table_view)
 
     def sizeHint(self):
-        return QSize(900, 500)
+        return QSize(1050, 500)
 
     def _filter_table_variables(self):
         regex = QRegExp(self.filter_string)

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -253,15 +253,26 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         for variables, x in matrices:
             result = np.full(len(variables), default_val)
 
+            # While the following caching and checks are messy, the indexing
+            # turns out to be a bottleneck for large datasets, so a single
+            # indexing operation improves performance
             disc_idx, cont_idx, time_idx, str_idx = self._attr_indices(variables)
-            if discrete_f and x[:, disc_idx].size:
-                result[disc_idx] = discrete_f(_to_float(x[:, disc_idx]))
-            if continuous_f and x[:, cont_idx].size:
-                result[cont_idx] = continuous_f(_to_float(x[:, cont_idx]))
-            if time_f and x[:, time_idx].size:
-                result[time_idx] = time_f(_to_float(x[:, time_idx]))
-            if string_f and x[:, str_idx].size:
-                result[str_idx] = string_f(_to_object(x[:, str_idx]))
+            if discrete_f:
+                x_ = x[:, disc_idx]
+                if x_.size:
+                    result[disc_idx] = discrete_f(_to_float(x_))
+            if continuous_f:
+                x_ = x[:, cont_idx]
+                if x_.size:
+                    result[cont_idx] = continuous_f(_to_float(x_))
+            if time_f:
+                x_ = x[:, time_idx]
+                if x_.size:
+                    result[time_idx] = time_f(_to_float(x_))
+            if string_f:
+                x_ = x[:, str_idx]
+                if x_.size:
+                    result[str_idx] = string_f(_to_object(x_))
 
             results.append(result)
 

--- a/orangecontrib/prototypes/widgets/owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/owfeaturestatistics.py
@@ -526,7 +526,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         # Consistently format the text inside the table cells
         # The easiest way to check for NaN is to compare with itself
         if output != output:
-            output = 'NaN'
+            output = ''
         # Format ∞ properly
         elif output in (np.inf, -np.inf):
             output = '%s∞' % ['', '-'][output < 0]

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -328,10 +328,14 @@ class TestFeatureStatisticsOutputs(WidgetTest):
             target=[rgb_full, rgb_missing], metas=[ints_full, ints_missing]
         )
         self.send_signal('Data', self.data)
+        self.cont_full_idx = self.widget.model.mapToSourceRows(0)
+        self.cont_miss_idx = self.widget.model.mapToSourceRows(1)
+        self.disc_full_idx = self.widget.model.mapToSourceRows(2)
+        self.ints_full_idx = self.widget.model.mapToSourceRows(4)
 
     def test_sends_single_attribute_table_to_output(self):
         # Check if selecting a single attribute row
-        self.widget.table_view.selectRow(0)
+        self.widget.table_view.selectRow(self.cont_full_idx)
         self.widget.unconditional_commit()
 
         desired_domain = Domain(attributes=[continuous_full.variable])
@@ -340,8 +344,8 @@ class TestFeatureStatisticsOutputs(WidgetTest):
 
     def test_sends_multiple_attribute_table_to_output(self):
         # Check if selecting a single attribute row
-        self.widget.table_view.selectRow(0)
-        self.widget.table_view.selectRow(1)
+        self.widget.table_view.selectRow(self.cont_full_idx)
+        self.widget.table_view.selectRow(self.cont_miss_idx)
         self.widget.unconditional_commit()
 
         desired_domain = Domain(attributes=[
@@ -351,7 +355,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.assertEqual(output.domain, desired_domain)
 
     def test_sends_single_class_var_table_to_output(self):
-        self.widget.table_view.selectRow(2)
+        self.widget.table_view.selectRow(self.disc_full_idx)
         self.widget.unconditional_commit()
 
         desired_domain = Domain(attributes=[], class_vars=[rgb_full.variable])
@@ -359,7 +363,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.assertEqual(output.domain, desired_domain)
 
     def test_sends_single_meta_table_to_output(self):
-        self.widget.table_view.selectRow(4)
+        self.widget.table_view.selectRow(self.ints_full_idx)
         self.widget.unconditional_commit()
 
         desired_domain = Domain(attributes=[], metas=[ints_full.variable])
@@ -367,9 +371,9 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.assertEqual(output.domain, desired_domain)
 
     def test_sends_multiple_var_types_table_to_output(self):
-        self.widget.table_view.selectRow(0)
-        self.widget.table_view.selectRow(2)
-        self.widget.table_view.selectRow(4)
+        self.widget.table_view.selectRow(self.cont_full_idx)
+        self.widget.table_view.selectRow(self.disc_full_idx)
+        self.widget.table_view.selectRow(self.ints_full_idx)
         self.widget.unconditional_commit()
 
         desired_domain = Domain(
@@ -382,8 +386,8 @@ class TestFeatureStatisticsOutputs(WidgetTest):
 
     def test_sends_all_samples_to_output(self):
         """All rows should be sent to output for selected column."""
-        self.widget.table_view.selectRow(0)
-        self.widget.table_view.selectRow(2)
+        self.widget.table_view.selectRow(self.cont_full_idx)
+        self.widget.table_view.selectRow(self.disc_full_idx)
         self.widget.unconditional_commit()
 
         selected_vars = Domain(

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from functools import wraps
 from itertools import chain
 from typing import Callable
@@ -11,74 +12,77 @@ from Orange.widgets.tests.utils import simulate
 from orangecontrib.prototypes.widgets.owfeaturestatistics import \
     OWFeatureStatistics
 
+VarDataPair = namedtuple('VarDataPair', ['variable', 'data'])
+
+
 # Continuous variable variations
-continuous_full = [
+continuous_full = VarDataPair(
     ContinuousVariable('continuous_full'),
     np.array([0, 1, 2, 3, 4], dtype=float),
-]
-continuous_missing = [
+)
+continuous_missing = VarDataPair(
     ContinuousVariable('continuous_missing'),
     np.array([0, 1, 2, np.nan, 4], dtype=float),
-]
-continuous_all_missing = [
+)
+continuous_all_missing = VarDataPair(
     ContinuousVariable('continuous_all_missing'),
     np.array([np.nan] * 5, dtype=float),
-]
-continuous_same = [
+)
+continuous_same = VarDataPair(
     ContinuousVariable('continuous_same'),
     np.array([3] * 5, dtype=float),
-]
+)
 continuous = [
     continuous_full, continuous_missing, continuous_all_missing,
     continuous_same
 ]
 
 # Unordered discrete variable variations
-rgb_full = [
+rgb_full = VarDataPair(
     DiscreteVariable('rgb_full', values=['r', 'g', 'b']),
     np.array([0, 1, 1, 1, 2], dtype=float),
-]
-rgb_missing = [
+)
+rgb_missing = VarDataPair(
     DiscreteVariable('rgb_missing', values=['r', 'g', 'b']),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
-]
-rgb_all_missing = [
+)
+rgb_all_missing = VarDataPair(
     DiscreteVariable('rgb_all_missing', values=['r', 'g', 'b']),
     np.array([np.nan] * 5, dtype=float),
-]
-rgb_bins_missing = [
+)
+rgb_bins_missing = VarDataPair(
     DiscreteVariable('rgb_bins_missing', values=['r', 'g', 'b']),
     np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
-]
-rgb_same = [
+)
+rgb_same = VarDataPair(
     DiscreteVariable('rgb_same', values=['r', 'g', 'b']),
     np.array([2] * 5, dtype=float),
-]
+)
 rgb = [
     rgb_full, rgb_missing, rgb_all_missing, rgb_bins_missing, rgb_same
 ]
 
 # Ordered discrete variable variations
-ints_full = [
+ints_full = VarDataPair(
     DiscreteVariable('ints_full', values=['2', '3', '4'], ordered=True),
     np.array([0, 1, 1, 1, 2], dtype=float),
-]
-ints_missing = [
+)
+ints_missing = VarDataPair(
     DiscreteVariable('ints_missing', values=['2', '3', '4'], ordered=True),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
-]
-ints_all_missing = [
+)
+ints_all_missing = VarDataPair(
     DiscreteVariable('ints_all_missing', values=['2', '3', '4'], ordered=True),
     np.array([np.nan] * 5, dtype=float),
-]
-ints_bins_missing = [
+)
+ints_bins_missing = VarDataPair(
     DiscreteVariable('ints_bins_missing', values=['2', '3', '4'], ordered=True),
     np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
-]
-ints_same = [
+)
+ints_same = VarDataPair(
     DiscreteVariable('ints_same', values=['2', '3', '4'], ordered=True),
     np.array([0] * 5, dtype=float),
-]
+)
 ints = [
     ints_full, ints_missing, ints_all_missing, ints_bins_missing, ints_same
 ]
@@ -86,43 +90,43 @@ ints = [
 discrete = list(chain(rgb, ints))
 
 # Time variable variations
-time_full = [
+time_full = VarDataPair(
     TimeVariable('time_full'),
     np.array([0, 1, 2, 3, 4], dtype=float),
-]
-time_missing = [
+)
+time_missing = VarDataPair(
     TimeVariable('time_missing'),
     np.array([0, np.nan, 2, 3, 4], dtype=float),
-]
-time_all_missing = [
+)
+time_all_missing = VarDataPair(
     TimeVariable('time_all_missing'),
     np.array([np.nan] * 5, dtype=float),
-]
-time_same = [
+)
+time_same = VarDataPair(
     TimeVariable('time_same'),
     np.array([4] * 5, dtype=float),
-]
+)
 time = [
     time_full, time_missing, time_all_missing, time_same
 ]
 
 # String variable variations
-string_full = [
+string_full = VarDataPair(
     StringVariable('string_full'),
     np.array(['a', 'b', 'c', 'd', 'e'], dtype=object),
-]
-string_missing = [
+)
+string_missing = VarDataPair(
     StringVariable('string_missing'),
     np.array(['a', 'b', 'c', StringVariable.Unknown, 'e'], dtype=object),
-]
-string_all_missing = [
+)
+string_all_missing = VarDataPair(
     StringVariable('string_all_missing'),
     np.array([StringVariable.Unknown] * 5, dtype=object),
-]
-string_same = [
+)
+string_same = VarDataPair(
     StringVariable('string_same'),
     np.array(['a'] * 5, dtype=object),
-]
+)
 string = [
     string_full, string_missing, string_all_missing, string_same
 ]
@@ -173,10 +177,10 @@ def table_dense_sparse(test_case):
     return _wrapper
 
 
-class TestOWFeatureStatistics(WidgetTest):
+class TestOWFeatureStatisticsTableTypes(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(
-            OWFeatureStatistics, stored_settings={"auto_apply": False}
+            OWFeatureStatistics, stored_settings={'auto_commit': False}
         )
 
     @table_dense_sparse
@@ -312,3 +316,91 @@ class TestOWFeatureStatistics(WidgetTest):
         # TODO: This does not actually test the crash because the histogram
         # code only runs when visible
         simulate.combobox_run_through_all(self.widget.cb_color_var)
+
+
+class TestFeatureStatisticsOutputs(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(
+            OWFeatureStatistics, stored_settings={'auto_commit': False}
+        )
+        self.data = make_table(
+            [continuous_full, continuous_missing],
+            target=[rgb_full, rgb_missing], metas=[ints_full, ints_missing]
+        )
+        self.send_signal('Data', self.data)
+
+    def test_sends_single_attribute_table_to_output(self):
+        # Check if selecting a single attribute row
+        self.widget.table_view.selectRow(0)
+        self.widget.unconditional_commit()
+
+        desired_domain = Domain(attributes=[continuous_full.variable])
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        self.assertEqual(output.domain, desired_domain)
+
+    def test_sends_multiple_attribute_table_to_output(self):
+        # Check if selecting a single attribute row
+        self.widget.table_view.selectRow(0)
+        self.widget.table_view.selectRow(1)
+        self.widget.unconditional_commit()
+
+        desired_domain = Domain(attributes=[
+            continuous_full.variable, continuous_missing.variable,
+        ])
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        self.assertEqual(output.domain, desired_domain)
+
+    def test_sends_single_class_var_table_to_output(self):
+        self.widget.table_view.selectRow(2)
+        self.widget.unconditional_commit()
+
+        desired_domain = Domain(attributes=[], class_vars=[rgb_full.variable])
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        self.assertEqual(output.domain, desired_domain)
+
+    def test_sends_single_meta_table_to_output(self):
+        self.widget.table_view.selectRow(4)
+        self.widget.unconditional_commit()
+
+        desired_domain = Domain(attributes=[], metas=[ints_full.variable])
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        self.assertEqual(output.domain, desired_domain)
+
+    def test_sends_multiple_var_types_table_to_output(self):
+        self.widget.table_view.selectRow(0)
+        self.widget.table_view.selectRow(2)
+        self.widget.table_view.selectRow(4)
+        self.widget.unconditional_commit()
+
+        desired_domain = Domain(
+            attributes=[continuous_full.variable],
+            class_vars=[rgb_full.variable],
+            metas=[ints_full.variable],
+        )
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        self.assertEqual(output.domain, desired_domain)
+
+    def test_sends_all_samples_to_output(self):
+        """All rows should be sent to output for selected column."""
+        self.widget.table_view.selectRow(0)
+        self.widget.table_view.selectRow(2)
+        self.widget.unconditional_commit()
+
+        selected_vars = Domain(
+            attributes=[continuous_full.variable],
+            class_vars=[rgb_full.variable],
+        )
+
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        np.testing.assert_equal(output.X, self.data[:, selected_vars].X)
+        np.testing.assert_equal(output.Y, self.data[:, selected_vars].Y)
+
+    def test_clearing_selection_sends_none_to_output(self):
+        """Clearing all the selected rows should send `None` to output."""
+        self.widget.table_view.selectRow(0)
+        self.widget.unconditional_commit()
+        self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
+
+        self.widget.table_view.clearSelection()
+        self.widget.unconditional_commit()
+        self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -400,7 +400,9 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.widget.table_view.selectRow(0)
         self.widget.unconditional_commit()
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
+        self.assertIsNotNone(self.get_output(self.widget.Outputs.statistics))
 
         self.widget.table_view.clearSelection()
         self.widget.unconditional_commit()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
+        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -406,3 +406,29 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.widget.unconditional_commit()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
         self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
+
+
+class TestFeatureStatisticsUI(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(
+            OWFeatureStatistics, stored_settings={'auto_commit': False}
+        )
+        self.data1 = Table('iris')
+        self.data2 = Table('zoo')
+
+    def test_restores_previous_selection(self):
+        """Widget should remember selection with domain context handler."""
+        # Send data and select rows
+        self.send_signal(self.widget.Inputs.data, self.data1)
+        self.widget.table_view.selectRow(0)
+        self.widget.table_view.selectRow(2)
+        self.assertEqual(len(self.widget.selected_rows), 2)
+
+        # Sending new data clears selection
+        self.send_signal(self.widget.Inputs.data, self.data2)
+        self.assertEqual(len(self.widget.selected_rows), 0)
+
+        # Sending back the old data restores the selection
+        self.send_signal(self.widget.Inputs.data, self.data1)
+        self.assertEqual(len(self.widget.selected_rows), 2)
+

--- a/orangecontrib/prototypes/widgets/utils/histogram.py
+++ b/orangecontrib/prototypes/widgets/utils/histogram.py
@@ -152,6 +152,8 @@ class Histogram(QGraphicsWidget):
         if self.color_attribute is not None:
             self.target_var = data.domain[color_attribute]
             self.y = data.get_column_view(color_attribute)[0]
+            if not np.issubdtype(self.y.dtype, np.number):
+                self.y = self.y.astype(np.float64)
         else:
             self.target_var, self.y = None, None
 
@@ -248,6 +250,12 @@ class Histogram(QGraphicsWidget):
             # TODO This probably also isn't the best handling of sparse data...
             if sp.issparse(y):
                 y = np.squeeze(np.array(y.todense()))
+
+            # Since y can contain missing values, we need to filter them out as
+            # well as their corresponding `x` values
+            y_nan_mask = np.isnan(y)
+            y, bin_indices = y[~y_nan_mask], bin_indices[~y_nan_mask]
+
             y = one_hot(y)
             bins = np.arange(self.n_bins)[:, np.newaxis]
             mask = bin_indices == bins


### PR DESCRIPTION
##### Description of changes
This turned very big, very fast. Sorry. I'll put other improvements in a separate PR, since this is already big as it is.

- Fixes #133 Sorting now works properly. I've also added variable type grouping, so that the dispersion in continuous variables is not mixed with modes of discrete variables, since it makes no sense to compare these. The sort order and column is stored as a ContextSetting
- Fixes #134 We don't show string variables anymore. After a bit of discussion in https://github.com/biolab/orange3/pull/2999, I realized treating time variables as ordinary continuous variables is perfectly reasonable. Center is the mean date, dispersion is the amount of time passed between the min and max date.
- Fixes #135 Outputs like in Rank. The selection is stored as a ContextSetting.
- Refactored most of the code so it's much clearer now, also improved performance by 1x.
- Fix crash on discrete target with missing values.



##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
