### PR TITLE
[FIX] Feature statistics fixes (pt. 2)

### DIFF
--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -237,6 +237,12 @@ class TestOWFeatureStatisticsTableTypes(WidgetTest):
         self.send_signal('Data', prepare_table(data))
         self.run_through_variables()
 
+    @table_dense_sparse
+    def test_on_data_with_continuous_values_all_the_same(self, prepare_table):
+        data = make_table([ints_full, ints_same], [continuous_same, continuous_full])
+        self.send_signal('Data', prepare_table(data))
+        self.run_through_variables()
+
 
 def select_rows(rows: List[int], widget: OWFeatureStatistics):
     """Since the widget sorts the rows, selecting rows isn't trivial."""

--- a/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owfeaturestatistics.py
@@ -231,6 +231,12 @@ class TestOWFeatureStatisticsTableTypes(WidgetTest):
         self.send_signal('Data', prepare_table(data))
         self.run_through_variables()
 
+    @table_dense_sparse
+    def test_on_data_with_discrete_values_all_the_same(self, prepare_table):
+        data = make_table([continuous_full], [ints_same, rgb_same])
+        self.send_signal('Data', prepare_table(data))
+        self.run_through_variables()
+
 
 def select_rows(rows: List[int], widget: OWFeatureStatistics):
     """Since the widget sorts the rows, selecting rows isn't trivial."""

--- a/orangecontrib/prototypes/widgets/utils/histogram.py
+++ b/orangecontrib/prototypes/widgets/utils/histogram.py
@@ -257,6 +257,14 @@ class Histogram(QGraphicsWidget):
             y, bin_indices = y[~y_nan_mask], bin_indices[~y_nan_mask]
 
             y = one_hot(y)
+            # In the event that y does not take up all the values and the
+            # largest discrete value does not appear at all, one hot encoding
+            # will produce too few columns. This causes problems, so we need to
+            # pad y with zeros to properly compute the distribution
+            if y.shape[1] != len(self.target_var.values):
+                n_missing_columns = len(self.target_var.values) - y.shape[1]
+                y = np.hstack((y, np.zeros((y.shape[0], n_missing_columns))))
+
             bins = np.arange(self.n_bins)[:, np.newaxis]
             mask = bin_indices == bins
             distributions = np.zeros((self.n_bins, y.shape[1]))

--- a/orangecontrib/prototypes/widgets/utils/histogram.py
+++ b/orangecontrib/prototypes/widgets/utils/histogram.py
@@ -227,7 +227,14 @@ class Histogram(QGraphicsWidget):
         else:
             edges = np.linspace(ut.nanmin(self.x), ut.nanmax(self.x), self.n_bins)
             edge_diff = edges[1] - edges[0]
-            return np.hstack((edges, [edges[-1] + edge_diff]))
+            edges = np.hstack((edges, [edges[-1] + edge_diff]))
+
+            # If the variable takes on a single value, we still need to spit
+            # out some reasonable bin edges
+            if np.all(edges == edges[0]):
+                edges = np.array([edges[0] - 1, edges[0], edges[0] + 1])
+
+            return edges
 
     def _get_bin_distributions(self, bin_indices):
         """Compute the distribution of instances within bins.
@@ -333,7 +340,9 @@ class Histogram(QGraphicsWidget):
 
             bins = np.arange(self.n_bins)[:, np.newaxis]
             edges = self.edges if self.attribute.is_discrete else self.edges[1:-1]
-            bin_indices = ut.digitize(self.x, bins=edges)
+            # Need to digitize on `right` here so the samples will be assigned
+            # to the correct bin for coloring
+            bin_indices = ut.digitize(self.x, bins=edges, right=True)
             mask = bin_indices == bins
 
             colors = []


### PR DESCRIPTION
##### Description of changes
Builds upon #137. This PR contains various fixes and improvements.

- 456c0ba widget would crash if given discrete variable where all the values would be the same
- f40a670 there was a coloring bug with continuous variables where all the values were the same. Discrete variables were colored incorrectly
- 7a8777a histograms would still show up if y was all nans and some sort of coloring was applied. Showing a histogram where the target var is all nans makes no sense, so hide them completely
- 6b79787 when inspecting a dataset with e.g. 40k variables, grouped sorting would result in a `MemoryError`. To fix this, the code is slightly uglier, but now sorting happens without issue and more efficiently.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
