### PR TITLE
Include data directory in the installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
             "orangecontrib.prototypes.widgets": ["icons/*.svg"],
             "orangecontrib.prototypes.widgets.utils": ["_plotly/*"],
             "orangecontrib.prototypes.widgets": ["_owparallelcoordiantes/*"],
+            "orangecontrib.prototypes.widgets": ["data/*"]
         },
         install_requires=[
             'Orange3',


### PR DESCRIPTION
##### Issue
When the `orange3-prototypes` is installed, the `data` directory is missing. This makes the **Webcam Widget crash** when a photo is taken because the `haarcascade_frontalface_default.xml` file in the `data` directory is not found.

##### Description of changes
Add one line in the `setup.py` to include the `data` directory.
