### PR TITLE
Change PyQt4 to AnyQt

### DIFF
--- a/orangecontrib/prototypes/widgets/owclock.py
+++ b/orangecontrib/prototypes/widgets/owclock.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from PyQt4.QtCore import Qt, QPoint, QDateTime, QSize, QRegExp
-from PyQt4.QtGui import QApplication, QCalendarWidget, QBrush, \
-    QWidget, QColor, QPainter, QLCDNumber, QPolygon, QSizePolicy, \
-    QAbstractButton
+from AnyQt.QtWidgets import QAbstractButton, QCalendarWidget, QWidget, \
+    QLCDNumber, QSizePolicy, QApplication
+from AnyQt.QtCore import QRegExp, QSize, QPoint, Qt, QDateTime
+from AnyQt.QtGui import QColor, QBrush, QPolygon, QPainter
 
 from Orange.data import Table
 from Orange.widgets import widget, gui

--- a/orangecontrib/prototypes/widgets/owdbscan.py
+++ b/orangecontrib/prototypes/widgets/owdbscan.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from PyQt4 import QtGui
+from AnyQt.QtWidgets import QLayout
 
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
@@ -74,7 +74,7 @@ class OWDBSCAN(widget.OWWidget):
         gui.rubber(self.controlArea)
 
         self.controlArea.setMinimumWidth(self.controlArea.sizeHint().width())
-        self.layout().setSizeConstraint(QtGui.QLayout.SetFixedSize)
+        self.layout().setSizeConstraint(QLayout.SetFixedSize)
 
     def adjustSize(self):
         self.ensurePolished()
@@ -158,7 +158,7 @@ class OWDBSCAN(widget.OWWidget):
 
 if __name__ == "__main__":
     import sys
-    from PyQt4.QtGui import QApplication
+    from AnyQt.QtWidgets import QApplication
 
     a = QApplication(sys.argv)
     ow = OWDBSCAN()

--- a/orangecontrib/prototypes/widgets/owhub.py
+++ b/orangecontrib/prototypes/widgets/owhub.py
@@ -1,5 +1,5 @@
-from PyQt4.QtGui import QListWidgetItem
-from PyQt4.QtCore import Qt, QSize
+from AnyQt.QtWidgets import QListWidgetItem
+from AnyQt.QtCore import Qt, QSize
 from Orange.widgets import widget, gui
 
 

--- a/orangecontrib/prototypes/widgets/owunique.py
+++ b/orangecontrib/prototypes/widgets/owunique.py
@@ -3,8 +3,8 @@ from operator import itemgetter
 
 import numpy as np
 
-from PyQt4.QtCore import Qt, QTimer
-from PyQt4.QtGui import QApplication, QListView
+from AnyQt.QtCore import Qt, QTimer
+from AnyQt.QtWidgets import QApplication, QListView
 
 from Orange.data import Table
 from Orange.widgets import widget, gui, settings


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Some widgets still used deprecated PyQt4.

##### Description of changes
Replace PyQt4 with AnyQt.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
