### PR TITLE
[ENH] Explanation widgets updates

### DIFF
--- a/orangecontrib/prototypes/widgets/owexplainmodel.py
+++ b/orangecontrib/prototypes/widgets/owexplainmodel.py
@@ -578,6 +578,11 @@ class OWExplainModel(OWWidget, ConcurrentWidgetMixin):
     def send_report(self):
         if not self.data or not self.model:
             return
+        items = {"Target class": "None"}
+        if self.model.domain.has_discrete_class:
+            class_var = self.model.domain.class_var
+            items["Target class"] = class_var.values[self.target_index]
+        self.report_items(items)
         self.report_plot()
 
 

--- a/orangecontrib/prototypes/widgets/owexplainpred.py
+++ b/orangecontrib/prototypes/widgets/owexplainpred.py
@@ -249,6 +249,12 @@ class StripeItem(QGraphicsWidget):
         self.__high_parts = []  # type: List[HighPartItem]
 
     @property
+    def total_width(self):
+        widths = [part.label_item.boundingRect().width()
+                  for part in self.__low_parts + self.__high_parts] + [0]
+        return self.WIDTH + StripePlot.SPACING + max(widths)
+
+    @property
     def model_output_ind(self) -> IndicatorItem:
         return self.__model_output_ind
 
@@ -446,7 +452,9 @@ class StripePlot(QGraphicsWidget):
         self.updateGeometry()
 
     def sizeHint(self, *_) -> QSizeF:
-        return QSizeF(200, self.height + self.MARGIN * 2)
+        return QSizeF(self.__left_axis.boundingRect().width() +
+                      self.__stripe_item.total_width + self.MARGIN * 2,
+                      self.height + self.MARGIN * 2)
 
 
 class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):

--- a/orangecontrib/prototypes/widgets/owexplainpred.py
+++ b/orangecontrib/prototypes/widgets/owexplainpred.py
@@ -678,8 +678,13 @@ class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):
         return sh.expandedTo(QSize(700, 700))
 
     def send_report(self):
-        if not self.data or not self.model:
+        if not self.data or not self.background_data or not self.model:
             return
+        items = {"Target class": "None"}
+        if self.model.domain.has_discrete_class:
+            class_var = self.model.domain.class_var
+            items["Target class"] = class_var.values[self.target_index]
+        self.report_items(items)
         self.report_plot()
 
 

--- a/orangecontrib/prototypes/widgets/owexplainpred.py
+++ b/orangecontrib/prototypes/widgets/owexplainpred.py
@@ -413,7 +413,8 @@ class AxisItem(pg.AxisItem):
 class StripePlot(QGraphicsWidget):
     HEIGHT = 400
     SPACING = 20
-    MARGIN = 30
+    HMARGIN = 30
+    VMARGIN = 20
 
     def __init__(self):
         super().__init__()
@@ -423,7 +424,8 @@ class StripePlot(QGraphicsWidget):
         self.__layout = QGraphicsLinearLayout()
         self.__layout.setOrientation(Qt.Horizontal)
         self.__layout.setSpacing(self.SPACING)
-        self.__layout.setContentsMargins(*[self.MARGIN] * 4)
+        self.__layout.setContentsMargins(self.HMARGIN, self.VMARGIN,
+                                         self.HMARGIN, self.VMARGIN)
         self.setLayout(self.__layout)
 
         self.__stripe_item = StripeItem(self)
@@ -440,7 +442,7 @@ class StripePlot(QGraphicsWidget):
         return self.HEIGHT + 10 * self.__height
 
     def set_data(self, data: PlotData, height: float):
-        diff = (data.value_range[1] - data.value_range[0]) * 0.1
+        diff = (data.value_range[1] - data.value_range[0]) * 0.01
         self.__range = (data.value_range[0] - diff, data.value_range[1] + diff)
         self.__left_axis.setRange(*self.__range)
         self.__height = height
@@ -453,8 +455,8 @@ class StripePlot(QGraphicsWidget):
 
     def sizeHint(self, *_) -> QSizeF:
         return QSizeF(self.__left_axis.boundingRect().width() +
-                      self.__stripe_item.total_width + self.MARGIN * 2,
-                      self.height + self.MARGIN * 2)
+                      self.__stripe_item.total_width + self.HMARGIN * 2,
+                      self.height + self.VMARGIN * 2)
 
 
 class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):
@@ -481,7 +483,7 @@ class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):
 
     settingsHandler = ClassValuesContextHandler()
     target_index = ContextSetting(0)
-    stripe_len = Setting(1)
+    stripe_len = Setting(10)
 
     graph_name = "scene"
 
@@ -673,7 +675,7 @@ class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):
 
     def sizeHint(self) -> QSizeF:
         sh = self.controlArea.sizeHint()
-        return sh.expandedTo(QSize(600, 520))
+        return sh.expandedTo(QSize(700, 700))
 
     def send_report(self):
         if not self.data or not self.model:

--- a/orangecontrib/prototypes/widgets/owexplainpred.py
+++ b/orangecontrib/prototypes/widgets/owexplainpred.py
@@ -168,8 +168,9 @@ class IndicatorItem(QGraphicsSimpleTextItem):
     PADDING = 2
     MARGIN = 10
 
-    def __init__(self):
+    def __init__(self, tooltip_prefix):
         super().__init__()
+        self.__tooltip_prefix = tooltip_prefix
         self.setPen(QPen(Qt.NoPen))
         self.setBrush(QColor(Qt.white))
 
@@ -179,7 +180,7 @@ class IndicatorItem(QGraphicsSimpleTextItem):
         except:
             n_dec = 2
         self.setText(_str(value, n_dec))
-        self.setToolTip(str(value))
+        self.setToolTip(self.__tooltip_prefix.format(value))
         width = self.boundingRect().width()
         self.setX(-width - self.MARGIN - self.PADDING - StripePlot.SPACING)
 
@@ -233,8 +234,9 @@ class StripeItem(QGraphicsWidget):
         self.__base_value_line = QGraphicsLineItem()
         self.__base_value_line.setPen(pen)
 
-        self.__model_output_ind = IndicatorItem()
-        self.__base_value_ind = IndicatorItem()
+        self.__model_output_ind = IndicatorItem("Model prediction: {}")
+        self.__base_value_ind = IndicatorItem("Base value: {}\nThe average "
+                                              "prediction for selected class.")
 
         self.__group.addToGroup(self.__low_item)
         self.__group.addToGroup(self.__high_item)
@@ -524,8 +526,9 @@ class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):
         gui.rubber(self.controlArea)
 
         box = gui.vBox(self.controlArea, "Prediction info")
-        gui.label(box, self, "%(mo_info)s")
-        gui.label(box, self, "%(bv_info)s")
+        gui.label(box, self, "%(mo_info)s")  # type: QLabel
+        bv_label = gui.label(box, self, "%(bv_info)s")  # type: QLabel
+        bv_label.setToolTip("The average prediction for selected class.")
 
     def __target_combo_changed(self):
         self.update_scene()
@@ -625,7 +628,7 @@ class OWExplainPrediction(OWWidget, ConcurrentWidgetMixin):
                                  base_value=base[self.target_index])
             self.setup_plot(plot_data)
 
-            self.mo_info = f"Model output: {_str(plot_data.model_output)}"
+            self.mo_info = f"Model prediction: {_str(plot_data.model_output)}"
             self.bv_info = f"Base value: {_str(plot_data.base_value)}"
 
             assert isinstance(self.__results.values, list)

--- a/orangecontrib/prototypes/widgets/tests/test_owexplainmodel.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owexplainmodel.py
@@ -231,6 +231,15 @@ class TestOWExplainModel(WidgetTest):
         self.wait_until_finished()
         self.assertFalse(self.widget.Information.data_sampled.is_shown())
 
+    def test_send_report(self):
+        self.widget.send_report()
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.send_signal(self.widget.Inputs.model, self.rf_cls)
+        self.widget.send_report()
+        self.send_signal(self.widget.Inputs.data, self.housing)
+        self.send_signal(self.widget.Inputs.model, self.rf_reg)
+        self.widget.send_report()
+
     def assertPlotEmpty(self, plot: ViolinPlot):
         self.assertIsNone(plot)
 

--- a/orangecontrib/prototypes/widgets/tests/test_owexplainpred.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owexplainpred.py
@@ -171,6 +171,17 @@ class TestOWExplainPrediction(WidgetTest):
         self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Information.multiple_instances.is_shown())
 
+    def test_send_report(self):
+        self.widget.send_report()
+        self.send_signal(self.widget.Inputs.data, self.iris[:1])
+        self.send_signal(self.widget.Inputs.background_data, self.iris)
+        self.send_signal(self.widget.Inputs.model, self.rf_cls)
+        self.widget.send_report()
+        self.send_signal(self.widget.Inputs.data, self.housing[:1])
+        self.send_signal(self.widget.Inputs.background_data, self.housing)
+        self.send_signal(self.widget.Inputs.model, self.rf_reg)
+        self.widget.send_report()
+
     def assertPlotEmpty(self, plot: StripePlot):
         self.assertIsNone(plot)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements #203

##### Description of changes
- change default zoom setting to something bigger
- (partially) Empty space above the stripe and below the stripe currently expand when zooming in. It would be better to always show just one tick (on the y-axis) above and one bellow the stripe.
- set tooltip at the model prediction number
- set tooltip at the base value number
- fix saved graph
- add target class to the report (explain model and explain prediction widgets)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
