### PR TITLE
[FIX] Explainer: fix case when data does not have domain

### DIFF
--- a/orangecontrib/prototypes/explanation/explainer.py
+++ b/orangecontrib/prototypes/explanation/explainer.py
@@ -119,8 +119,8 @@ def _explain_trees(
     # TreeExplaner cannot explain in normal time more cases than 10000
     data_sample, sample_mask = _subsample_data(transformed_data, 10000)
     num_classes = (
-        len(transformed_data.domain.class_var.values)
-        if transformed_data.domain.class_var.is_discrete
+        len(model.domain.class_var.values)
+        if model.domain.class_var.is_discrete
         else None
     )
 
@@ -443,7 +443,7 @@ def explain_predictions(
     progress_callback(0)
 
     predictions = model(
-        data, model.Probs if data.domain.class_var.is_discrete else model.Value
+        data, model.Probs if model.domain.class_var.is_discrete else model.Value
     )
     # for regression - predictions array is 1d transform it shape N x 1
     if predictions.ndim == 1:

--- a/orangecontrib/prototypes/explanation/explainer.py
+++ b/orangecontrib/prototypes/explanation/explainer.py
@@ -9,7 +9,7 @@ from sklearn.cluster import KMeans
 from sklearn.impute import SimpleImputer
 
 from Orange.base import Model
-from Orange.data import Table
+from Orange.data import Table, Domain
 from Orange.util import dummy_callback, wrap_callback
 from shap import KernelExplainer, TreeExplainer
 from shap.common import DenseData, SHAPError, sample
@@ -442,8 +442,13 @@ def explain_predictions(
         progress_callback = dummy_callback
     progress_callback(0)
 
+    # prediction happens independent from the class -
+    # same than for prediction widget
+    classless_data = data.transform(
+        Domain(data.domain.attributes, None, data.domain.metas)
+    )
     predictions = model(
-        data, model.Probs if model.domain.class_var.is_discrete else model.Value
+        classless_data, model.Probs if model.domain.class_var.is_discrete else model.Value
     )
     # for regression - predictions array is 1d transform it shape N x 1
     if predictions.ndim == 1:

--- a/orangecontrib/prototypes/explanation/tests/test_explainer.py
+++ b/orangecontrib/prototypes/explanation/tests/test_explainer.py
@@ -9,7 +9,7 @@ from Orange.classification import (
     SVMLearner,
     TreeLearner,
 )
-from Orange.data import Table
+from Orange.data import Table, Domain
 from Orange.regression import LinearRegressionLearner
 from Orange.tests.test_classification import LearnerAccessibility
 from Orange.tests.test_regression import TestRegression
@@ -541,6 +541,29 @@ class TestExplainer(unittest.TestCase):
             labels,
         )
         self.assertListEqual([(-5, 4), (3, 13), (-6, 4)], ranges)
+
+    def test_no_class(self):
+        iris_no_class = Table.from_table(
+            Domain(self.iris.domain.attributes), self.iris
+        )
+
+        # tree
+        model = RandomForestLearner()(self.iris)
+        shap_values, _, sample_mask, _ = compute_shap_values(
+            model, iris_no_class, iris_no_class
+        )
+
+        self.assertTupleEqual(self.iris.X.shape, shap_values[0].shape)
+        self.assertTupleEqual((len(self.iris),), sample_mask.shape)
+
+        # kernel
+        model = LogisticRegressionLearner()(self.iris)
+        shap_values, _, sample_mask, _ = compute_shap_values(
+            model, iris_no_class, iris_no_class
+        )
+
+        self.assertTupleEqual(self.iris.X.shape, shap_values[0].shape)
+        self.assertTupleEqual((len(self.iris),), sample_mask.shape)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/prototypes/widgets/tests/test_owexplainpred.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owexplainpred.py
@@ -52,7 +52,7 @@ class TestOWExplainPrediction(WidgetTest):
         self.send_signal(self.widget.Inputs.model, self.rf_reg)
         self.wait_until_finished()
         self.assertPlotEmpty(self.widget._stripe_plot)
-        self.assertTrue(self.widget.Error.unknown_err.is_shown())
+        self.assertTrue(self.widget.Error.domain_transform_err.is_shown())
 
     def test_regression_data_regression_model(self):
         self.send_signal(self.widget.Inputs.background_data, self.housing)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It is possible that explained data have no class_var. In this case, the explanation failed since it was checking the class_var.

##### Description of changes
Whenever class_var is required use domain from the model.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
