### PR TITLE
CreateTable: fix float is continuous

### DIFF
--- a/orangecontrib/prototypes/widgets/owcreatetable.py
+++ b/orangecontrib/prototypes/widgets/owcreatetable.py
@@ -63,13 +63,26 @@ class EditableTableModel(QAbstractTableModel):
 
     def is_discrete(self, column):
         column_data = set(row[column] for row in self._table) - {None}
+
+        def is_number(x):
+            """
+            Check if x is number
+            x.is_digit only works for usigned ints this on works for ints and
+            floats
+            """
+            try:
+                float(x)
+                return True
+            except ValueError:
+                return False
+
         return (
             self._domain is not None
             and self._domain[column].is_discrete
             or (
                 column_data
                 and not self.is_time_variable(column)
-                and not all(map(lambda s: s.isdigit(), column_data))
+                and not all(map(lambda s: is_number(s), column_data))
             )
         )
 

--- a/orangecontrib/prototypes/widgets/tests/test_owcreatetable.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owcreatetable.py
@@ -52,7 +52,7 @@ class TestOWCreateTable(WidgetTest):
             self.assertSetEqual(cv, set(a.values))
 
     def test_continuous_columns(self):
-        _input = [["1", "2", "3"], ["4", "5", "6"]]
+        _input = [["1", "2.0", "3"], ["4", "5.0", "6"]]
         self.widget.table_model.set_table(_input)
         self.wait_until_finished()
         output = self.get_output(self.widget.Outputs.data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-prototypes/issues/222

##### Description of changes
Float values are recognized as continuous now.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
