### PR TITLE
[ENH] Interactions widget

### DIFF
--- a/orangecontrib/prototypes/widgets/owinteractions.py
+++ b/orangecontrib/prototypes/widgets/owinteractions.py
@@ -1,0 +1,213 @@
+"""
+Interactions widget
+"""
+from operator import attrgetter
+from itertools import chain
+
+import numpy as np
+
+from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QStandardItem
+
+from Orange.data import Table
+from Orange.widgets import gui
+from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.utils.signals import Input, Output
+from Orange.widgets.utils.widgetpreview import WidgetPreview
+from Orange.widgets.widget import OWWidget, AttributeList, Msg
+from Orange.widgets.data.owcorrelations import CorrelationRank, OWCorrelations
+from Orange.preprocess import Discretize
+from Orange.preprocess.discretize import EqualFreq
+
+
+SIZE_LIMIT = 1000000
+
+
+class Interaction:
+	def __init__(self, disc_data):
+		self.data = disc_data
+		self.n_attrs = len(self.data.domain.attributes)
+		self.class_h = self.entropy(self.data.Y)
+		self.attr_h = np.zeros(self.n_attrs)
+		self.gains = np.zeros(self.n_attrs)
+		self.removed_h = np.zeros((self.n_attrs, self.n_attrs))
+		self.compute_gains()
+
+	@staticmethod
+	def distribution(ar):
+		nans = np.isnan(ar)
+		if nans.any():
+			if len(ar.shape) == 1:
+				ar = ar[~nans]
+			else:
+				ar = ar[~nans.any(axis=1)]
+		_, counts = np.unique(ar, return_counts=True, axis=0)
+		return counts / len(ar)
+
+	def entropy(self, ar):
+		p = self.distribution(ar)
+		return -np.sum(p * np.log2(p))
+
+	def compute_gains(self):
+		for attr in range(self.n_attrs):
+			self.attr_h[attr] = self.entropy(self.data.X[:, attr])
+			self.gains[attr] = self.attr_h[attr] + self.class_h \
+				- self.entropy(np.c_[self.data.X[:, attr], self.data.Y])
+
+	def __call__(self, attr1, attr2):
+		attrs = np.c_[self.data.X[:, attr1], self.data.X[:, attr2]]
+		self.removed_h[attr1, attr2] = self.entropy(attrs) + self.class_h - self.entropy(np.c_[attrs, self.data.Y])
+		return self.removed_h[attr1, attr2] - self.gains[attr1] - self.gains[attr2]
+
+
+class Heuristic:
+	def __init__(self, weights):
+		self.n = len(weights)
+		self.w = weights.copy()
+		self.a = np.arange(self.n)
+		self.a = self.a[np.argsort(self.w)]
+
+	def generate_states(self):
+		# prioritize two mid ranked attributes over highest first
+		for s in range(1, self.n * (self.n - 1) // 2):
+			for i in range(max(s - self.n + 1, 0), (s + 1) // 2):
+				yield self.a[i], self.a[s - i]
+
+	def get_states(self, initial_state):
+		states = self.generate_states()
+		if initial_state is not None:
+			while next(states) != initial_state:
+				pass
+			return chain([initial_state], states)
+		return states
+
+
+class InteractionRank(CorrelationRank):
+	def __init__(self, *args):
+		super().__init__(*args)
+
+	def initialize(self):
+		super(CorrelationRank, self).initialize()
+		data = self.master.disc_data
+		self.attrs = data and data.domain.attributes
+		self.model_proxy.setFilterKeyColumn(-1)
+		self.interaction = Interaction(data)
+		self.heuristic = None
+		self.use_heuristic = False
+		self.sel_feature_index = self.master.feature and data.domain.index(self.master.feature)
+		if data:
+			self.use_heuristic = len(data) * len(self.attrs) ** 2 > SIZE_LIMIT
+			if self.use_heuristic and not self.sel_feature_index:
+				self.heuristic = Heuristic(self.interaction.gains)
+
+	def compute_score(self, state):
+		attr1, attr2 = state
+		score = self.interaction(attr1, attr2) / self.interaction.class_h
+		gain1 = self.interaction.gains[attr1] / self.interaction.class_h
+		gain2 = self.interaction.gains[attr2] / self.interaction.class_h
+		removed = self.interaction.removed_h[attr1, attr2] / self.interaction.class_h
+		return -score, score, gain1, gain2, removed
+
+	def row_for_state(self, score, state):
+		attrs = sorted((self.attrs[x] for x in state), key=attrgetter("name"))
+		attr_items = []
+		for i, attr in enumerate(attrs):
+			item = QStandardItem(attr.name)
+			item.setData(attrs, self._AttrRole)
+			item.setData(Qt.AlignLeft + Qt.AlignTop, Qt.TextAlignmentRole)
+			item.setToolTip("Attribute Info: {:.1f}%".format(100*score[2+i]))
+			attr_items.append(item)
+		interaction_item = QStandardItem("{:+.1f}%".format(100*score[1]))
+		interaction_item.setData(attrs, self._AttrRole)
+		interaction_item.setData(
+			self.NEGATIVE_COLOR if score[1] < 0 else self.POSITIVE_COLOR,
+			gui.TableBarItem.BarColorRole)
+		interaction_item.setToolTip("Entropy removed: {:.1f}%".format(100*score[4]))
+		return [interaction_item] + attr_items
+
+	def check_preconditions(self):
+		return self.master.disc_data is not None
+
+
+class OWInteractions(OWCorrelations):
+	name = "Interactions"
+	description = "Compute all pairwise attribute interactions."
+
+	class Inputs:
+		data = Input("Data", Table)
+
+	class Outputs:
+		features = Output("Features", AttributeList)
+
+	class Warning(OWWidget.Warning):
+		not_enough_vars = Msg("At least two features are needed.")
+		not_enough_inst = Msg("At least two instances are needed.")
+
+	def __init__(self):
+		super(OWCorrelations, self).__init__()
+		self.data = None  # type: Table
+		self.disc_data = None  # type: Table
+
+		# GUI
+		box = gui.vBox(self.controlArea)
+		self.feature_model = DomainModel(
+			order=DomainModel.ATTRIBUTES, separators=False,
+			placeholder="(All combinations)")
+		gui.comboBox(
+			box, self, "feature", callback=self._feature_combo_changed,
+			model=self.feature_model
+		)
+
+		self.vizrank, _ = InteractionRank.add_vizrank(
+			None, self, None, self._vizrank_selection_changed)
+		self.vizrank.button.setEnabled(False)
+		self.vizrank.threadStopped.connect(self._vizrank_stopped)
+
+		gui.separator(box)
+		box.layout().addWidget(self.vizrank.filter)
+		box.layout().addWidget(self.vizrank.rank_table)
+
+		button_box = gui.hBox(self.buttonsArea)
+		button_box.layout().addWidget(self.vizrank.button)
+
+	@Inputs.data
+	def set_data(self, data):
+		self.closeContext()
+		self.clear_messages()
+		self.data = data
+		self.disc_data = None
+		self.selection = []
+		if data is not None:
+			if len(data) < 2:
+				self.Warning.not_enough_inst()
+			else:
+				disc_data = Discretize(method=EqualFreq())(data)
+				if len(disc_data.domain.attributes) < 2:
+					self.Warning.not_enough_vars()
+				else:
+					self.disc_data = disc_data
+		self.feature_model.set_domain(self.disc_data and self.disc_data.domain)
+		self.openContext(self.disc_data)
+		self.apply()
+		self.vizrank.button.setEnabled(self.disc_data is not None)
+
+	def apply(self):
+		self.vizrank.initialize()
+		if self.disc_data is not None:
+			# this triggers self.commit() by changing vizrank selection
+			self.vizrank.toggle()
+		else:
+			self.commit()
+
+	def commit(self):
+		if self.data is None or self.disc_data is None:
+			self.Outputs.features.send(None)
+			return
+
+		# data has been imputed; send original attributes
+		self.Outputs.features.send(AttributeList(
+			[self.data.domain[var.name] for var in self.selection]))
+
+
+if __name__ == "__main__":  # pragma: no cover
+	WidgetPreview(OWInteractions).run(Table("iris"))

--- a/orangecontrib/prototypes/widgets/owinteractions.py
+++ b/orangecontrib/prototypes/widgets/owinteractions.py
@@ -15,9 +15,9 @@ from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.signals import Input, Output
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, AttributeList, Msg
-from Orange.widgets.data.owcorrelations import CorrelationRank, OWCorrelations
 from Orange.preprocess import Discretize, Remove
 from Orange.preprocess.discretize import EqualFreq
+import Orange.widgets.data.owcorrelations
 
 
 SIZE_LIMIT = 1000000
@@ -82,7 +82,7 @@ class Heuristic:
 		return states
 
 
-class InteractionRank(CorrelationRank):
+class InteractionRank(Orange.widgets.data.owcorrelations.CorrelationRank):
 	IntRole = next(gui.OrangeUserRole)
 	RemovedRole = next(gui.OrangeUserRole)
 
@@ -91,7 +91,7 @@ class InteractionRank(CorrelationRank):
 		self.interaction = None
 
 	def initialize(self):
-		super(CorrelationRank, self).initialize()
+		super(Orange.widgets.data.owcorrelations.CorrelationRank, self).initialize()
 		data = self.master.disc_data
 		self.attrs = data and data.domain.attributes
 		self.model_proxy.setFilterKeyColumn(-1)
@@ -136,9 +136,10 @@ class InteractionRank(CorrelationRank):
 		return self.master.disc_data is not None
 
 
-class OWInteractions(OWCorrelations):
+class OWInteractions(Orange.widgets.data.owcorrelations.OWCorrelations):
 	name = "Interactions"
 	description = "Compute all pairwise attribute interactions."
+	category = None
 
 	class Inputs:
 		data = Input("Data", Table)
@@ -152,7 +153,7 @@ class OWInteractions(OWCorrelations):
 		not_enough_inst = Msg("At least two instances are needed.")
 
 	def __init__(self):
-		super(OWCorrelations, self).__init__()
+		super(Orange.widgets.data.owcorrelations.OWCorrelations, self).__init__()
 		self.data = None  # type: Table
 		self.disc_data = None  # type: Table
 

--- a/orangecontrib/prototypes/widgets/tests/test_owinteractions.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owinteractions.py
@@ -7,7 +7,6 @@ import numpy.testing as npt
 from AnyQt.QtCore import Qt
 
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
-from Orange.tests import test_filename
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 from Orange.widgets.visualize.owscatterplot import OWScatterPlot

--- a/orangecontrib/prototypes/widgets/tests/test_owinteractions.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owinteractions.py
@@ -1,0 +1,273 @@
+import unittest
+from unittest.mock import patch, Mock
+
+import numpy as np
+import numpy.testing as npt
+
+from AnyQt.QtCore import Qt
+
+from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
+from Orange.tests import test_filename
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.utils import simulate
+from Orange.widgets.visualize.owscatterplot import OWScatterPlot
+from Orange.widgets.widget import AttributeList
+from orangecontrib.prototypes.widgets.owinteractions import OWInteractions, Heuristic, Interaction, InteractionRank
+
+
+class TestOWInteractions(WidgetTest):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.data = Table("iris")
+		cls.disc_data = Table("zoo")
+
+	def setUp(self):
+		self.widget = self.create_widget(OWInteractions)
+
+	def test_input_data(self):
+		"""Check interaction table"""
+		self.send_signal(self.widget.Inputs.data, None)
+		self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 0)
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		n_attrs = len(self.data.domain.attributes)
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 3)
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), n_attrs*(n_attrs-1)/2)
+
+	def test_input_data_one_feature(self):
+		"""Check interaction table for dataset with one attribute"""
+		self.send_signal(self.widget.Inputs.data, self.data[:, [0, 4]])
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
+		self.assertTrue(self.widget.Warning.not_enough_vars.is_shown())
+		self.send_signal(self.widget.Inputs.data, None)
+		self.assertFalse(self.widget.Warning.not_enough_vars.is_shown())
+
+	def test_input_data_one_instance(self):
+		"""Check interaction table for dataset with one instance"""
+		self.send_signal(self.widget.Inputs.data, self.data[:1])
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
+		self.assertFalse(self.widget.Information.removed_cons_feat.is_shown())
+		self.assertTrue(self.widget.Warning.not_enough_inst.is_shown())
+		self.send_signal(self.widget.Inputs.data, None)
+		self.assertFalse(self.widget.Warning.not_enough_inst.is_shown())
+
+	def test_input_data_with_constant_features(self):
+		"""Check interaction table for dataset with constant columns"""
+		np.random.seed(0)
+		x = np.random.randint(3, size=(4, 3)).astype(float)
+		x[:, 2] = 1
+		y = np.random.randint(3, size=4).astype(float)
+
+		domain_disc = Domain([DiscreteVariable(str(i), ["a", "b", "c"]) for i in range(3)], DiscreteVariable("cls"))
+		domain_cont = Domain([ContinuousVariable(str(i)) for i in range(3)], DiscreteVariable("cls"))
+
+		self.send_signal(self.widget.Inputs.data, Table(domain_disc, x, y))
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 3)
+		self.assertFalse(self.widget.Information.removed_cons_feat.is_shown())
+
+		self.send_signal(self.widget.Inputs.data, Table(domain_cont, x, y))
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 1)
+		self.assertTrue(self.widget.Information.removed_cons_feat.is_shown())
+
+		x = np.ones((4, 3), dtype=float)
+		self.send_signal(self.widget.Inputs.data, Table(domain_cont, x, y))
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
+		self.assertTrue(self.widget.Warning.not_enough_vars.is_shown())
+		self.assertTrue(self.widget.Information.removed_cons_feat.is_shown())
+
+		self.send_signal(self.widget.Inputs.data, None)
+		self.assertFalse(self.widget.Information.removed_cons_feat.is_shown())
+
+	def test_output_features(self):
+		"""Check features on output"""
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		self.process_events()
+		features = self.get_output(self.widget.Outputs.features)
+		self.assertIsInstance(features, AttributeList)
+		self.assertEqual(len(features), 2)
+
+	def test_output_interactions(self):
+		"""Check interaction table on output"""
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		n_attrs = len(self.data.domain.attributes)
+		self.process_events()
+		interactions = self.get_output(self.widget.Outputs.interactions)
+		self.assertIsInstance(interactions, Table)
+		self.assertEqual(len(interactions), n_attrs*(n_attrs-1)/2)
+		self.assertEqual(len(interactions.domain.metas), 2)
+		self.assertListEqual(["Interaction", "Entropy Removed"], [m.name for m in interactions.domain.attributes])
+
+	def test_input_changed(self):
+		"""Check whether changing input emits commit"""
+		self.widget.commit = Mock()
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		self.process_events()
+		self.widget.commit.assert_called_once()
+
+		np.random.seed(0)
+		x = np.random.randint(3, size=(4, 3)).astype(float)
+		y = np.random.randint(3, size=4).astype(float)
+		domain = Domain([DiscreteVariable(str(i), ["a", "b", "c"]) for i in range(3)], DiscreteVariable("cls"))
+
+		self.widget.commit.reset_mock()
+		self.send_signal(self.widget.Inputs.data, Table(domain, x, y))
+		self.wait_until_finished()
+		self.process_events()
+		self.widget.commit.assert_called_once()
+
+	def test_saved_selection(self):
+		"""Select row from settings"""
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		self.process_events()
+		attrs = self.widget.disc_data.domain.attributes
+		self.widget._vizrank_selection_changed(attrs[1], attrs[3])
+		settings = self.widget.settingsHandler.pack_data(self.widget)
+
+		w = self.create_widget(OWInteractions, stored_settings=settings)
+		self.send_signal(self.widget.Inputs.data, self.data, widget=w)
+		self.wait_until_finished(w)
+		self.process_events()
+		sel_row = w.vizrank.rank_table.selectionModel().selectedRows()[0].row()
+		self.assertEqual(sel_row, 1)
+
+	def test_scatterplot_input_features(self):
+		"""Check if attributes have been set after sent to scatterplot"""
+		self.send_signal(self.widget.Inputs.data, self.data)
+		spw = self.create_widget(OWScatterPlot)
+		attrs = self.widget.disc_data.domain.attributes
+		self.widget._vizrank_selection_changed(attrs[2], attrs[3])
+		features = self.get_output(self.widget.Outputs.features)
+		self.send_signal(self.widget.Inputs.data, self.data, widget=spw)
+		self.send_signal(spw.Inputs.features, features, widget=spw)
+		self.assertIs(spw.attr_x, self.data.domain[2])
+		self.assertIs(spw.attr_y, self.data.domain[3])
+
+	def test_heuristic(self):
+		"""Check attribute pairs returned by heuristic"""
+		score = Interaction(self.disc_data)
+		heuristic = Heuristic(score.gains)
+		self.assertListEqual(
+			list(heuristic.get_states(None))[:10],
+			[(14, 6), (14, 10), (14, 15), (6, 10), (14, 5), (6, 15), (14, 11), (6, 5), (10, 15), (14, 4)]
+		)
+
+		states = heuristic.get_states(None)
+		_ = next(states)
+		self.assertListEqual(
+			list(heuristic.get_states(next(states)))[:9],
+			[(14, 10), (14, 15), (6, 10), (14, 5), (6, 15), (14, 11), (6, 5), (10, 15), (14, 4)]
+		)
+
+	def test_feature_combo(self):
+		"""Check content of feature selection combobox"""
+		feature_combo = self.widget.controls.feature
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.assertEqual(len(feature_combo.model()), 5)
+
+		self.wait_until_stop_blocking()
+		self.send_signal(self.widget.Inputs.data, self.disc_data)
+		self.assertEqual(len(feature_combo.model()), 17)
+
+	def test_select_feature(self):
+		"""Check feature selection"""
+		feature_combo = self.widget.controls.feature
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 6)
+		self.assertListEqual(
+			[a.name for a in self.get_output(self.widget.Outputs.features)],
+			["sepal length", "sepal width"]
+		)
+
+		simulate.combobox_activate_index(feature_combo, 3)
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 3)
+		self.assertListEqual(
+			[a.name for a in self.get_output(self.widget.Outputs.features)],
+			["petal length", "sepal width"]
+		)
+
+		simulate.combobox_activate_index(feature_combo, 0)
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 6)
+		self.assertListEqual(
+			[a.name for a in self.get_output(self.widget.Outputs.features)],
+			["petal length", "sepal width"]
+		)
+
+	@patch("orangecontrib.prototypes.widgets.owinteractions.SIZE_LIMIT", 2000)
+	def test_vizrank_use_heuristic(self):
+		"""Check heuristic use"""
+		self.send_signal(self.widget.Inputs.data, self.data)
+		self.wait_until_finished()
+		self.process_events()
+		self.assertTrue(self.widget.vizrank.use_heuristic)
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 6)
+
+	@patch("orangecontrib.prototypes.widgets.owinteractions.SIZE_LIMIT", 2000)
+	def test_select_feature_against_heuristic(self):
+		"""Never use heuristic if feature is selected"""
+		feature_combo = self.widget.controls.feature
+		self.send_signal(self.widget.Inputs.data, self.data)
+		simulate.combobox_activate_index(feature_combo, 2)
+		self.wait_until_finished()
+		self.process_events()
+		self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 3)
+		self.assertEqual(self.widget.vizrank.heuristic, None)
+
+
+class TestInteractionRank(WidgetTest):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		x = np.array([[1, 1], [0, 1], [1, 1], [0, 0]])
+		y = np.array([0, 1, 1, 1])
+		domain = Domain([DiscreteVariable(str(i)) for i in range(2)], DiscreteVariable("3"))
+		cls.data = Table(domain, x, y)
+		cls.attrs = cls.data.domain.attributes
+
+	def setUp(self):
+		self.vizrank = InteractionRank(None)
+		self.vizrank.attrs = self.attrs
+
+	def test_compute_score(self):
+		"""Check score calculation"""
+		self.vizrank.master = Mock()
+		self.vizrank.interaction = Interaction(self.data)
+		npt.assert_almost_equal(
+			self.vizrank.compute_score((0, 1)),
+			[0.1511, -0.1511, 0.3837, 0.1511, 0.3837], 4
+		)
+
+	def test_row_for_state(self):
+		"""Check row calculation"""
+		row = self.vizrank.row_for_state((-0.1511, 0.1511, 0.3837, 0.1511, 0.3837), (0, 1))
+		self.assertEqual(row[0].data(Qt.DisplayRole), "+15.1%")
+		self.assertEqual(row[0].data(InteractionRank.IntRole), 0.1511)
+		self.assertEqual(row[0].data(InteractionRank.RemovedRole), 0.3837)
+		self.assertEqual(row[1].data(Qt.DisplayRole), self.attrs[0].name)
+		self.assertEqual(row[2].data(Qt.DisplayRole), self.attrs[1].name)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
##### Description of changes
Adds widget for calculation of attribute interactions based on Orange's correlations widget. The returned results are consistent with the Interaction Graph widget from Orange2, however this is somewhat dependant on the discretization of the input data (this one handles continuous data via equal-frequency discretization). 

To simplify the code this widget inherits directly from owcorrelations, so the following Warning is raised:
`RuntimeWarning: subclassing of widget classes is deprecated and will be disabled in the future.
Extract code from OWCorrelations or explicitly open it by adding 'openclass=True' to class definition.
  class OWInteractions(OWCorrelations):`
The solution is probably to construct a combined parent class for both owcorrelations and owinteractions.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
