### PR TITLE
Split: whitespace and empty space

### DIFF
--- a/orangecontrib/prototypes/widgets/owsplit.py
+++ b/orangecontrib/prototypes/widgets/owsplit.py
@@ -19,7 +19,8 @@ class SplitColumn:
         self.delimiter = delimiter
 
         column = self.get_string_values(data, self.attr)
-        values = [s.split(self.delimiter) for s in column]
+        values = [[t.strip() for t in s.split(self.delimiter)]
+                  for s in column]
         self.new_values = tuple(sorted({val if val else "?" for vals in
                                         values for val in vals}))
 
@@ -32,9 +33,10 @@ class SplitColumn:
 
     def __call__(self, data):
         column = self.get_string_values(data, self.attr)
-        values = [set(s.split(self.delimiter)) for s in column]
-        shared_data = {v: [i for i, xs in enumerate(values) if v in xs] for v
-                       in self.new_values}
+        values = [{t.strip() for t in s.split(self.delimiter)}
+                  for s in column]
+        shared_data = {v: [i for i, xs in enumerate(values) if v in xs]
+                       for v in self.new_values}
         return shared_data
 
     @staticmethod

--- a/orangecontrib/prototypes/widgets/owsplit.py
+++ b/orangecontrib/prototypes/widgets/owsplit.py
@@ -19,7 +19,7 @@ class SplitColumn:
         self.delimiter = delimiter
 
         column = self.get_string_values(data, self.attr)
-        values = [[t.strip() for t in s.split(self.delimiter)]
+        values = [[x for x in (t.strip() for t in s.split(self.delimiter)) if x]
                   for s in column]
         self.new_values = tuple(sorted({val if val else "?" for vals in
                                         values for val in vals}))

--- a/orangecontrib/prototypes/widgets/tests/test_owsplit.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owsplit.py
@@ -34,7 +34,7 @@ class TestOWSplit(WidgetTest):
             [
                 ["foo,"],
                 ["bar,baz "],
-                ["foo,bar"],
+                ["foo, bar"],
                 [""],
             ]
         )

--- a/orangecontrib/prototypes/widgets/tests/test_owsplit.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owsplit.py
@@ -99,9 +99,10 @@ class TestOWSplit(WidgetTest):
         variable name."""
         self.widget.delimiter = ","
         self.send_signal(self.widget.Inputs.data, self.small_table)
-        # new columns will be ["?", "bar", "baz ", "foo (1)"]
-        self.assertEqual(len(self.get_output(self.widget.Outputs.data).domain),
-                         5)
+        out = self.get_output(self.widget.Outputs.data)
+        self.assertEqual(
+            {var.name for var in out.domain.attributes},
+            {"bar", "baz", "foo (1)"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

1. Comma-separated text usually includes a space after comma. When widgets splits by comma, we then have two attributes - those starting with space and those without. Whitespace at the beginning and end is not shown, hence having it will never be intentional, imho. Thus it needs to be removed.
2. If empty strings are considered missing then in case the string is empty, values of all new variables should be shown as missing. Current implementation instead adds an indicator variable for missing strings, which is probably not even used, (r used in case of two consecutive delimiters?) 
3. However, instead of fixing 2, I'd prefer to interpret empty strings differently in this context: they are empty because they do not contain any of the values into which the string is split. I think this makes more sense.

##### Description of changes

Fix 1, fix 2 via 3.

##### Includes
- [X] Code changes
- [X] Tests
