### PR TITLE
OWTextToColumns: add name migration

### DIFF
--- a/orangecontrib/prototypes/widgets/owtexttocolumns.py
+++ b/orangecontrib/prototypes/widgets/owtexttocolumns.py
@@ -91,6 +91,7 @@ class OWTextToColumns(OWWidget):
     icon = "icons/TextToColumns.svg"
     keywords = ["split"]
     priority = 700
+    replaces = ["orangecontrib.prototypes.widgets.owsplit.OWSplit"]
 
     class Inputs:
         data = Input("Data", Table)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Old workflows with OWSplit didn't work.

##### Description of changes
Ensure name migration.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
