### PR TITLE
Text to Columns: Fix dtype for empty arrays

### DIFF
--- a/orangecontrib/prototypes/widgets/owtexttocolumns.py
+++ b/orangecontrib/prototypes/widgets/owtexttocolumns.py
@@ -31,7 +31,8 @@ class SplitColumn:
         column = data.get_column(self.attr)
         values = [{ss.strip() for ss in s.split(self.delimiter)}
                   for s in column]
-        return {v: np.array([i for i, xs in enumerate(values) if v in xs])
+        return {v: np.array([i for i, xs in enumerate(values) if v in xs],
+                            dtype=int)
                 for v in self.new_values}
 
     def __eq__(self, other):

--- a/orangecontrib/prototypes/widgets/tests/test_owtexttocolumns.py
+++ b/orangecontrib/prototypes/widgets/tests/test_owtexttocolumns.py
@@ -47,6 +47,17 @@ class TestComputation(unittest.TestCase):
         np.testing.assert_equal(shared["f o"], [0, 1])
         np.testing.assert_equal(shared["o"], [2])
 
+    def test_no_known_values(self):
+        sc = SplitColumn(self.data, self.data.domain.metas[0], ",")
+        data = Table.from_numpy(
+            self.data.domain, np.zeros((3, 1)), None,
+            np.array([["x"] * 2] * 3))
+        shared = sc(data)
+        for attr in ("a", "bbb", "d"):
+            self.assertEqual(shared[attr].size, 0)
+            oh = OneHotStrings(sc, attr)
+            np.testing.assert_equal(oh(data), [0, 0, 0])
+
     def test_one_hot_strings(self):
         attr = self.data.domain.metas[0]
         sc = SplitColumn(self.data, attr, ",")


### PR DESCRIPTION
##### Issue

Fixes #274.

The speed up in a74ea0605fcda4f0247fd1a066a14db1e06053d3 fails if some variable doesn't appear in any row. The reason is that the table of row indices that contain this value will be empty and empty arrays have a `dtype` `float`.

In #274, this happened because tables are converted in batches of 5000 rows, and there were batches that didn't contain some values.

In another scenario, this would happen in the domain conversion would be applied on a data different from the one on which it was created.

##### Description of changes

Add `dtype=int`.

##### Includes
- [X] Code changes
- [X] Tests
